### PR TITLE
feat: allow undo action in the text editor

### DIFF
--- a/NeoCode/AppShell/ComposerViews.swift
+++ b/NeoCode/AppShell/ComposerViews.swift
@@ -1015,6 +1015,7 @@ struct GrowingTextView: NSViewRepresentable {
         textView.isAutomaticQuoteSubstitutionEnabled = false
         textView.isAutomaticDashSubstitutionEnabled = false
         textView.isAutomaticTextReplacementEnabled = false
+        textView.allowsUndo = true
         textView.usesRolloverButtonForSelection = false
         if #available(macOS 15.0, *) {
             textView.writingToolsBehavior = .none


### PR DESCRIPTION
I expected `⌘+Z` and `Shift+⌘+Z`  to work when writing in the chat. I built it from source and confirmed the change works.

Really nice project BTW!