### PR TITLE
chore: support local signing override via User.xcconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ updates/
 bin/
 appcast.xml
 .DS_Store
+User.xcconfig

--- a/justfile
+++ b/justfile
@@ -21,6 +21,8 @@ clean:
     rm -rf "{{build_dir}}" "{{dmg_dir}}" DerivedData updates appcast.xml
     @echo "Done"
 
+user_xcconfig := if `test -f User.xcconfig` != "" { "User.xcconfig" } else { "" }
+
 build:
     @echo "Building {{app_name}} (Debug)..."
     xcodebuild \
@@ -28,6 +30,7 @@ build:
         -scheme {{scheme}} \
         -configuration Debug \
         -derivedDataPath DerivedData \
+        {{ if user_xcconfig != "" { "-xcconfig " + user_xcconfig } else { "" } }} \
         build
 
 build-release:
@@ -37,6 +40,7 @@ build-release:
         -scheme {{scheme}} \
         -configuration Release \
         -derivedDataPath DerivedData \
+        {{ if user_xcconfig != "" { "-xcconfig " + user_xcconfig } else { "" } }} \
         build
 
 test:


### PR DESCRIPTION
## Summary

- Adds `User.xcconfig` to `.gitignore`
- Wires `just build` and `just build-release` to load `User.xcconfig` when present via `-xcconfig`

## Motivation

Contributors with different Apple Developer team IDs can set `DEVELOPMENT_TEAM` in a local `User.xcconfig` instead of modifying `project.pbxproj`.

## Status

**WIP / Untested** — feedback welcome.