### PR TITLE
feat: add Cmd+, keyboard shortcut to open in-app settings

### DIFF
--- a/NeoCode/NeoCodeApp.swift
+++ b/NeoCode/NeoCodeApp.swift
@@ -8,6 +8,10 @@
 import AppKit
 import SwiftUI
 
+extension Notification.Name {
+    static let openNeoCodeSettings = Notification.Name("openNeoCodeSettings")
+}
+
 @main
 struct NeoCodeApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
@@ -23,6 +27,14 @@ struct NeoCodeApp: App {
         .defaultSize(width: 1280, height: 900)
         .windowResizability(.contentMinSize)
         .windowStyle(.hiddenTitleBar)
+        .commands {
+            CommandGroup(replacing: .appSettings) {
+                Button("Settings...") {
+                    NotificationCenter.default.post(name: .openNeoCodeSettings, object: nil)
+                }
+                .keyboardShortcut(",", modifiers: .command)
+            }
+        }
     }
 }
 
@@ -206,9 +218,12 @@ private struct UnitTestHostView: View {
                         window.alphaValue = 0
                         window.ignoresMouseEvents = true
                         window.orderOut(nil)
-                    }
-                }
             }
+            .onReceive(NotificationCenter.default.publisher(for: .openNeoCodeSettings)) { _ in
+                store.openSettings()
+            }
+    }
+}
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds **Cmd+,** keyboard shortcut that opens the in-app Settings panel
- Replaces the default macOS "Settings..." menu entry (which opens System Settings) with a local notification bridge to `store.openSettings()`

## How it works

`NeoCodeApp.swift` registers a `.commands { CommandGroup(replacing: .appSettings) }` on the `WindowGroup` that posts `.openNeoCodeSettings`. `AppSceneView` observes the notification and calls `store.openSettings()`.

## Status

**WIP / Untested** — awaiting Metal toolchain download to complete build verification. Feedback welcome.