### PR TITLE
feat: add Remove Project action to sidebar

### DIFF
--- a/NeoCode/AppShell/SidebarViews.swift
+++ b/NeoCode/AppShell/SidebarViews.swift
@@ -210,6 +210,7 @@ struct ProjectTreeNode: View {
     @Environment(\.locale) private var locale
     @State private var isHovering = false
     @State private var showsAllSessions = false
+    @State private var showsRemoveConfirmation = false
 
     private let workspaceToolService = WorkspaceToolService()
 
@@ -286,6 +287,14 @@ struct ProjectTreeNode: View {
         }
         .opacity(isBeingDragged ? 0.7 : 1)
         .animation(.easeOut(duration: 0.12), value: isDropTarget)
+        .alert(localized("Remove Project", locale: locale), isPresented: $showsRemoveConfirmation) {
+            Button(localized("Cancel", locale: locale), role: .cancel) {}
+            Button(localized("Remove", locale: locale), role: .destructive) {
+                store.removeProject(project.id, using: runtime)
+            }
+        } message: {
+            Text(String(format: localized("Remove \"%@\" from the sidebar?", locale: locale), project.name))
+        }
     }
 
     private var disclosureIcon: String {
@@ -330,6 +339,12 @@ struct ProjectTreeNode: View {
 
                 Button(localized("Open Project", locale: locale), action: openProject)
                 Button(localized("Reveal in Finder", locale: locale), action: revealProject)
+
+                Divider()
+
+                Button(localized("Remove Project", locale: locale), role: .destructive) {
+                    removeProjectConfirmation = true
+                }
             } label: {
                 Image(systemName: "ellipsis")
                     .font(.system(size: 12, weight: .medium))

--- a/NeoCode/AppStore.swift
+++ b/NeoCode/AppStore.swift
@@ -847,6 +847,24 @@ final class AppStore {
         moveProject(from: sourceIndex, to: projects.count - 1)
     }
 
+    func removeProject(_ projectID: ProjectSummary.ID, using runtime: OpenCodeRuntime) {
+        guard let index = projects.firstIndex(where: { $0.id == projectID }) else { return }
+
+        disconnectLiveState(for: projectID)
+        runtime.stop(projectPath: projectPath(for: projectID))
+        projects.remove(at: index)
+
+        if selectedProjectID == projectID {
+            selectedProjectID = projects.first?.id
+            selectedSessionID = nil
+            loadingTranscriptSessionID = nil
+            primePromptState(for: nil)
+        }
+
+        scheduleProjectPersistence()
+        reevaluateRuntimeRetention(using: runtime)
+    }
+
     func toggleProjectCollapsed(_ projectID: ProjectSummary.ID) {
         setProjectCollapsed(!isProjectCollapsed(projectID), for: projectID)
     }

--- a/NeoCode/Localization/Localizable.xcstrings
+++ b/NeoCode/Localization/Localizable.xcstrings
@@ -1,12910 +1,12930 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "" : {
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ""
+  "sourceLanguage": "en",
+  "strings": {
+    "": {
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ""
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ""
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ""
           }
         }
       }
     },
-    "-%lld" : {
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "-%lld"
+    "-%lld": {
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "-%lld"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "-%lld"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "-%lld"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "-%lld"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "-%lld"
           }
         }
       }
     },
-    "/%@" : {
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "/%@"
+    "/%@": {
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "/%@"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "/%@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "/%@"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "/%@"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "/%@"
           }
         }
       }
     },
-    "/opt/homebrew/bin/opencode" : {
-
-    },
-    "#000000" : {
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "#000000"
+    "/opt/homebrew/bin/opencode": {},
+    "#000000": {
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#000000"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "#000000"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#000000"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "#000000"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#000000"
           }
         }
       }
     },
-    "%@ earlier message hidden" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ earlier message hidden"
+    "%@ earlier message hidden": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ earlier message hidden"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ mensaje anterior oculto"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ mensaje anterior oculto"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ message précédent masqué"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ message précédent masqué"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ messaggio precedente nascosto"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ messaggio precedente nascosto"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ mensagem anterior oculta"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ mensagem anterior oculta"
           }
         }
       }
     },
-    "%@ earlier messages hidden" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ earlier messages hidden"
+    "%@ earlier messages hidden": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ earlier messages hidden"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ mensajes anteriores ocultos"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ mensajes anteriores ocultos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ messages précédents masqués"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ messages précédents masqués"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ messaggi precedenti nascosti"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ messaggi precedenti nascosti"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ mensagens anteriores ocultas"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ mensagens anteriores ocultas"
           }
         }
       }
     },
-    "%@ messages · %@ tokens" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ messages · %2$@ tokens"
+    "%@ messages · %@ tokens": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ messages · %2$@ tokens"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ mensajes · %2$@ tokens"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ mensajes · %2$@ tokens"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ messages · %2$@ jetons"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ messages · %2$@ jetons"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ messaggi · %2$@ token"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ messaggi · %2$@ token"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ mensagens · %2$@ tokens"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ mensagens · %2$@ tokens"
           }
         }
       }
     },
-    "%@ of %@ cached" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ of %2$@ cached"
+    "%@ of %@ cached": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ of %2$@ cached"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ de %2$@ en cache"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ de %2$@ en cache"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ sur %2$@ mis en cache"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ sur %2$@ mis en cache"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ di %2$@ memorizzati nella cache"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ di %2$@ memorizzati nella cache"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ de %2$@ em cache"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ de %2$@ em cache"
           }
         }
       }
     },
-    "%@ remaining - %@ used" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ remaining - %2$@ used"
+    "%@ remaining - %@ used": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ remaining - %2$@ used"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quedan %1$@ - usado %2$@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quedan %1$@ - usado %2$@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ restants - %2$@ utilisés"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ restants - %2$@ utilisés"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ rimanenti - %2$@ usati"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ rimanenti - %2$@ usati"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ restantes - %2$@ usados"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ restantes - %2$@ usados"
           }
         }
       }
     },
-    "%@ remaining - %@ used - projected after compaction" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ remaining - %2$@ used - projected after compaction"
+    "%@ remaining - %@ used - projected after compaction": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ remaining - %2$@ used - projected after compaction"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quedan %1$@ - usado %2$@ - proyectado tras la compactacion"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quedan %1$@ - usado %2$@ - proyectado tras la compactacion"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ restants - %2$@ utilisés - projetés après compactage"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ restants - %2$@ utilisés - projetés après compactage"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ rimanenti - %2$@ usati - proiezione dopo la compattazione"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ rimanenti - %2$@ usati - proiezione dopo la compattazione"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ restantes - %2$@ usados - projetado após compactação"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ restantes - %2$@ usados - projetado após compactação"
           }
         }
       }
     },
-    "%@ sessions" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ sessions"
+    "%@ sessions": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ sessions"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ sesiones"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ sesiones"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ sessions"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ sessions"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ sessioni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ sessioni"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ sessões"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ sessões"
           }
         }
       }
     },
-    "%@ tokens · %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ tokens · %2$@"
+    "%@ tokens · %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ tokens · %2$@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ jetons · %2$@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ jetons · %2$@"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ token · %2$@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ token · %2$@"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ tokens · %2$@"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ tokens · %2$@"
           }
         }
       }
     },
-    "%@ user · %@ assistant" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ user · %2$@ assistant"
+    "%@ user · %@ assistant": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ user · %2$@ assistant"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ usuario · %2$@ asistente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ usuario · %2$@ asistente"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ utilisateur · %2$@ assistant"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ utilisateur · %2$@ assistant"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ utente · %2$@ assistente"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ utente · %2$@ assistente"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ usuário · %2$@ assistente"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ usuário · %2$@ assistente"
           }
         }
       }
     },
-    "%@/%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@/%2$@"
+    "%@/%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@/%2$@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@/%2$@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@/%2$@"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@/%2$@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@/%2$@"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@/%2$@"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@/%2$@"
           }
         }
       }
     },
-    "%lld" : {
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld"
+    "%lld": {
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld"
           }
         }
       }
     },
-    "%lld percent context remaining" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld percent context remaining"
+    "%lld percent context remaining": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld percent context remaining"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Queda %lld por ciento de contexto"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Queda %lld por ciento de contexto"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld % de contexte restants"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld % de contexte restants"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld percentuale di contesto rimanente"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld percentuale di contesto rimanente"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld por cento de contexto restante"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld por cento de contexto restante"
           }
         }
       }
     },
-    "%lld%% context remaining" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld%% context remaining"
+    "%lld%% context remaining": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld%% context remaining"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Queda %lld%% de contexto"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Queda %lld%% de contexto"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld%% de contexte restant"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld%% de contexte restant"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld%% contesto rimanente"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld%% contesto rimanente"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld%% de contexto restante"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld%% de contexto restante"
           }
         }
       }
     },
-    "+%lld" : {
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "+%lld"
+    "+%lld": {
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "+%lld"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "+%lld"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "+%lld"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "+%lld"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "+%lld"
           }
         }
       }
     },
-    "7 days" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "7 days"
+    "7 days": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7 days"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "7 dias"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7 dias"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "7 jours"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7 jours"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "7 giorni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7 giorni"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "7 dias"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7 dias"
           }
         }
       }
     },
-    "30 days" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30 days"
+    "30 days": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 days"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30 dias"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 dias"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30 jours"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 jours"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30 giorni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 giorni"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30 dias"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 dias"
           }
         }
       }
     },
-    "90 days" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "90 days"
+    "90 days": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "90 days"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "90 dias"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "90 dias"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "90 jours"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "90 jours"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "90 giorni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "90 giorni"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "90 dias"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "90 dias"
           }
         }
       }
     },
-    "A cached view of model mix, token totals, tool usage, and project activity across your tracked OpenCode workspaces." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A cached view of model mix, token totals, tool usage, and project activity across your tracked OpenCode workspaces."
+    "A cached view of model mix, token totals, tool usage, and project activity across your tracked OpenCode workspaces.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A cached view of model mix, token totals, tool usage, and project activity across your tracked OpenCode workspaces."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Una vista en cache de la mezcla de modelos, tokens totales, uso de herramientas y actividad por proyecto en tus espacios de trabajo de OpenCode seguidos."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una vista en cache de la mezcla de modelos, tokens totales, uso de herramientas y actividad por proyecto en tus espacios de trabajo de OpenCode seguidos."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Une vue mise en cache du mélange de modèles, des totaux de jetons, de l'utilisation des outils et de l'activité des projets OpenCode suivis."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une vue mise en cache du mélange de modèles, des totaux de jetons, de l'utilisation des outils et de l'activité des projets OpenCode suivis."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Una visualizzazione memorizzata nella cache del mix di modelli, dei totali di token, dell'uso degli strumenti e dell'attività dei progetti nelle workspace OpenCode monitorate."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una visualizzazione memorizzata nella cache del mix di modelli, dei totali di token, dell'uso degli strumenti e dell'attività dei progetti nelle workspace OpenCode monitorate."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uma visão em cache da mistura de modelos, totais de tokens, uso de ferramentas e atividade do projeto em seus espaços de trabalho OpenCode rastreados."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uma visão em cache da mistura de modelos, totais de tokens, uso de ferramentas e atividade do projeto em seus espaços de trabalho OpenCode rastreados."
           }
         }
       }
     },
-    "Accent" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accent"
+    "Accent": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accent"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acento"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acento"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accent"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accent"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accento"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accento"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Destaque"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Destaque"
           }
         }
       }
     },
-    "Add" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajouter"
+    "Add": {
+      "extractionState": "stale",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiungi"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiungi"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adicionar"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionar"
           }
         }
       }
     },
-    "Add a custom response" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add a custom response"
+    "Add a custom response": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add a custom response"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Añadir una respuesta personalizada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Añadir una respuesta personalizada"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajouter une réponse personnalisée"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter une réponse personnalisée"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiungi una risposta personalizzata"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiungi una risposta personalizzata"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adicionar uma resposta personalizada"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionar uma resposta personalizada"
           }
         }
       }
     },
-    "Add project" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add project"
+    "Add project": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add project"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anadir proyecto"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anadir proyecto"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajouter un projet"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter un projet"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiungi progetto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiungi progetto"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adicionar projeto"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionar projeto"
           }
         }
       }
     },
-    "Add to favorites" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add to favorites"
+    "Add to favorites": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add to favorites"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Agregar a favoritos"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Agregar a favoritos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ajouter aux favoris"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ajouter aux favoris"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Aggiungi ai preferiti"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Aggiungi ai preferiti"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Adicionar aos favoritos"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Adicionar aos favoritos"
           }
         }
       }
     },
-    "Add your first project" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajoutez votre premier projet"
+    "Add your first project": {
+      "extractionState": "stale",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajoutez votre premier projet"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiungi il tuo primo progetto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiungi il tuo primo progetto"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adicione seu primeiro projeto"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicione seu primeiro projeto"
           }
         }
       }
     },
-    "Adjust cursor behavior and base sizing. Font families now live with each theme profile above." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adjust cursor behavior and base sizing. Font families now live with each theme profile above."
+    "Adjust cursor behavior and base sizing. Font families now live with each theme profile above.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adjust cursor behavior and base sizing. Font families now live with each theme profile above."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajusta el comportamiento del cursor y el tamano base. Las familias tipograficas ahora viven en cada perfil de tema de arriba."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajusta el comportamiento del cursor y el tamano base. Las familias tipograficas ahora viven en cada perfil de tema de arriba."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajuste le comportement du curseur et la taille de base. Les familles de polices sont désormais définies dans chaque profil de thème ci-dessus."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajuste le comportement du curseur et la taille de base. Les familles de polices sont désormais définies dans chaque profil de thème ci-dessus."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Regola il comportamento del cursore e le dimensioni base. Ora le famiglie di font vivono con ogni profilo tema sopra."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Regola il comportamento del cursore e le dimensioni base. Ora le famiglie di font vivono con ogni profilo tema sopra."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajuste o comportamento do cursor e o dimensionamento base. As famílias de fontes agora ficam com cada perfil de tema acima."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajuste o comportamento do cursor e o dimensionamento base. As famílias de fontes agora ficam com cada perfil de tema acima."
           }
         }
       }
     },
-    "Adjusts separation between surfaces, borders, and low-emphasis text." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adjusts separation between surfaces, borders, and low-emphasis text."
+    "Adjusts separation between surfaces, borders, and low-emphasis text.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adjusts separation between surfaces, borders, and low-emphasis text."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajusta la separacion entre superficies, bordes y texto de baja enfasis."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajusta la separacion entre superficies, bordes y texto de baja enfasis."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajuste la séparation entre les surfaces, les bordures et les textes à faible emphase."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajuste la séparation entre les surfaces, les bordures et les textes à faible emphase."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Regola la separazione tra superfici, bordi e testo a bassa enfasi."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Regola la separazione tra superfici, bordi e testo a bassa enfasi."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajusta a separação entre superfícies, bordas e texto de baixa ênfase."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajusta a separação entre superfícies, bordas e texto de baixa ênfase."
           }
         }
       }
     },
-    "Affected patterns" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Affected patterns"
+    "Affected patterns": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Affected patterns"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Patrones afectados"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Patrones afectados"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modèles affectés"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modèles affectés"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pattern interessati"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pattern interessati"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Padrões afetados"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Padrões afetados"
           }
         }
       }
     },
-    "Agent" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agent"
+    "Agent": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agente"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agent"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agente"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agente"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agente"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agente"
           }
         }
       }
     },
-    "Agent activity" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agent activity"
+    "Agent activity": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent activity"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actividad del agente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actividad del agente"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activité de l'agent"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activité de l'agent"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Attività agente"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attività agente"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atividade do agente"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atividade do agente"
           }
         }
       }
     },
-    "Agent is retrying" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Agent is retrying"
+    "Agent is retrying": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Agent is retrying"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "El agente está reintentando"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "El agente está reintentando"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "L'agent réessaye"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "L'agent réessaye"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "L'agente sta ritentando"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "L'agente sta ritentando"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "O agente está tentando novamente"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "O agente está tentando novamente"
           }
         }
       }
     },
-    "Agent is working" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Agent is working"
+    "Agent is working": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Agent is working"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "El agente está trabajando"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "El agente está trabajando"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "L'agent est en action"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "L'agent est en action"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "L'agente sta lavorando"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "L'agente sta lavorando"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "O agente está trabalhando"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "O agente está trabalhando"
           }
         }
       }
     },
-    "All time" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "All time"
+    "All time": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All time"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Todo el tiempo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todo el tiempo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tout le temps"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout le temps"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tutto il tempo"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tutto il tempo"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Todo o tempo"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todo o tempo"
           }
         }
       }
     },
-    "Allow `%@`" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allow `%@`"
+    "Allow `%@`": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow `%@`"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir `%@`"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir `%@`"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autoriser `%@`"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autoriser `%@`"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consenti `%@`"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consenti `%@`"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir `%@`"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir `%@`"
           }
         }
       }
     },
-    "Allow always" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allow always"
+    "Allow always": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow always"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir siempre"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir siempre"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toujours autoriser"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toujours autoriser"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consenti sempre"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consenti sempre"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir sempre"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir sempre"
           }
         }
       }
     },
-    "Allow content search" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allow content search"
+    "Allow content search": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow content search"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir búsqueda de contenido"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir búsqueda de contenido"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autoriser la recherche dans le contenu"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autoriser la recherche dans le contenu"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consenti ricerca nel contenuto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consenti ricerca nel contenuto"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir busca de conteúdo"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir busca de conteúdo"
           }
         }
       }
     },
-    "Allow continued execution" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allow continued execution"
+    "Allow continued execution": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow continued execution"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir ejecución continua"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir ejecución continua"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autoriser l'exécution continue"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autoriser l'exécution continue"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consenti esecuzione continua"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consenti esecuzione continua"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir execução contínua"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir execução contínua"
           }
         }
       }
     },
-    "Allow directory listing" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allow directory listing"
+    "Allow directory listing": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow directory listing"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir listado de directorios"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir listado de directorios"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autoriser la liste des dossiers"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autoriser la liste des dossiers"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consenti elenco directory"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consenti elenco directory"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir listagem de diretórios"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir listagem de diretórios"
           }
         }
       }
     },
-    "Allow external directory access" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allow external directory access"
+    "Allow external directory access": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow external directory access"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir acceso a directorio externo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir acceso a directorio externo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autoriser l'accès à un dossier externe"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autoriser l'accès à un dossier externe"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consenti accesso a directory esterna"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consenti accesso a directory esterna"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir acesso a diretório externo"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir acesso a diretório externo"
           }
         }
       }
     },
-    "Allow file edits" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allow file edits"
+    "Allow file edits": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow file edits"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir ediciones de archivos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir ediciones de archivos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autoriser les modifications de fichiers"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autoriser les modifications de fichiers"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consenti modifiche ai file"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consenti modifiche ai file"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir edições de arquivos"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir edições de arquivos"
           }
         }
       }
     },
-    "Allow file globbing" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allow file globbing"
+    "Allow file globbing": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow file globbing"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir glob de archivos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir glob de archivos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autoriser le filtrage de fichiers"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autoriser le filtrage de fichiers"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consenti glob dei file"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consenti glob dei file"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir glob de arquivos"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir glob de arquivos"
           }
         }
       }
     },
-    "Allow file reads" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allow file reads"
+    "Allow file reads": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow file reads"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir lecturas de archivos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir lecturas de archivos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autoriser la lecture de fichiers"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autoriser la lecture de fichiers"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consenti lettura file"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consenti lettura file"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir leitura de arquivos"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir leitura de arquivos"
           }
         }
       }
     },
-    "Allow once" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allow once"
+    "Allow once": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow once"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir una vez"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir una vez"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autoriser une fois"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autoriser une fois"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consenti una volta"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consenti una volta"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir uma vez"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir uma vez"
           }
         }
       }
     },
-    "Allow shell command" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allow shell command"
+    "Allow shell command": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow shell command"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir comando de shell"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir comando de shell"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autoriser la commande shell"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autoriser la commande shell"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consenti comando shell"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consenti comando shell"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir comando de shell"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir comando de shell"
           }
         }
       }
     },
-    "Allow subagent task" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allow subagent task"
+    "Allow subagent task": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow subagent task"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir tarea de subagente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir tarea de subagente"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autoriser la tâche de sous-agent"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autoriser la tâche de sous-agent"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consenti attività del subagente"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consenti attività del subagente"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir tarefa de subagente"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir tarefa de subagente"
           }
         }
       }
     },
-    "Allow web fetch" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allow web fetch"
+    "Allow web fetch": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow web fetch"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir obtención web"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir obtención web"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autoriser la récupération web"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autoriser la récupération web"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consenti recupero web"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consenti recupero web"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir carregamento web"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir carregamento web"
           }
         }
       }
     },
-    "Allow web search" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allow web search"
+    "Allow web search": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow web search"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir búsqueda web"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir búsqueda web"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autoriser la recherche web"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autoriser la recherche web"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consenti ricerca web"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consenti ricerca web"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir busca na web"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir busca na web"
           }
         }
       }
     },
-    "Allowed forever if approved" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allowed forever if approved"
+    "Allowed forever if approved": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allowed forever if approved"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitido para siempre si se aprueba"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitido para siempre si se aprueba"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autorisé indéfiniment si approuvé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autorisé indéfiniment si approuvé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consentito per sempre se approvato"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consentito per sempre se approvato"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitido para sempre se aprovado"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitido para sempre se aprovado"
           }
         }
       }
     },
-    "Answer the questions below to let the agent continue." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Answer the questions below to let the agent continue."
+    "Answer the questions below to let the agent continue.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Answer the questions below to let the agent continue."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Responde las preguntas siguientes para que el agente pueda continuar."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Responde las preguntas siguientes para que el agente pueda continuar."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Répondez aux questions ci-dessous pour permettre à l'agent de continuer."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Répondez aux questions ci-dessous pour permettre à l'agent de continuer."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rispondi alle domande qui sotto per permettere all'agente di continuare."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rispondi alle domande qui sotto per permettere all'agente di continuare."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Responda às perguntas abaixo para permitir que o agente continue."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Responda às perguntas abaixo para permitir que o agente continue."
           }
         }
       }
     },
-    "Appearance" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Appearance"
+    "Appearance": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Appearance"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apariencia"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apariencia"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apparence"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apparence"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aspetto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aspetto"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aparência"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aparência"
           }
         }
       }
     },
-    "Apply available update" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apply available update"
+    "Apply available update": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apply available update"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aplicar actualizacion disponible"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicar actualizacion disponible"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Appliquer la mise à jour disponible"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Appliquer la mise à jour disponible"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Applica aggiornamento disponibile"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Applica aggiornamento disponibile"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aplicar atualização disponível"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicar atualização disponível"
           }
         }
       }
     },
-    "Ask macOS to keep the system awake while NeoCode is actively processing a response." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ask macOS to keep the system awake while NeoCode is actively processing a response."
+    "Ask macOS to keep the system awake while NeoCode is actively processing a response.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ask macOS to keep the system awake while NeoCode is actively processing a response."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pide a macOS que mantenga el sistema activo mientras NeoCode procesa una respuesta."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pide a macOS que mantenga el sistema activo mientras NeoCode procesa una respuesta."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Demandez à macOS de rester éveillé pendant que NeoCode traite une réponse."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Demandez à macOS de rester éveillé pendant que NeoCode traite une réponse."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chiedi a macOS di mantenere il sistema attivo mentre NeoCode elabora una risposta."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chiedi a macOS di mantenere il sistema attivo mentre NeoCode elabora una risposta."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Peça ao macOS para manter o sistema ativo enquanto o NeoCode estiver processando uma resposta."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Peça ao macOS para manter o sistema ativo enquanto o NeoCode estiver processando uma resposta."
           }
         }
       }
     },
-    "Ask Sparkle to validate the newest available release right now." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ask Sparkle to validate the newest available release right now."
+    "Ask Sparkle to validate the newest available release right now.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ask Sparkle to validate the newest available release right now."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pide a Sparkle que valide ahora mismo la version mas reciente disponible."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pide a Sparkle que valide ahora mismo la version mas reciente disponible."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Demandez à Sparkle de valider immédiatement la dernière version disponible."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Demandez à Sparkle de valider immédiatement la dernière version disponible."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chiedi a Sparkle di convalidare subito la release più recente disponibile."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chiedi a Sparkle di convalidare subito la release più recente disponibile."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Peça ao Sparkle para validar a versão mais recente disponível agora."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Peça ao Sparkle para validar a versão mais recente disponível agora."
           }
         }
       }
     },
-    "Attach Files..." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Attach Files..."
+    "Attach Files...": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attach Files..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adjuntar archivos..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adjuntar archivos..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Joindre des fichiers..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Joindre des fichiers..."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allega file..."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allega file..."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anexar arquivos..."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anexar arquivos..."
           }
         }
       }
     },
-    "Auto detect" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auto detect"
+    "Auto detect": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto detect"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detectar automaticamente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detectar automaticamente"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Détection automatique"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Détection automatique"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rilevamento automatico"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rilevamento automatico"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detecção automática"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detecção automática"
           }
         }
       }
     },
-    "Automatic checks" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatic checks"
+    "Automatic checks": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatic checks"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comprobaciones automaticas"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprobaciones automaticas"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vérifications automatiques"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifications automatiques"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Controlli automatici"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Controlli automatici"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificações automáticas"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificações automáticas"
           }
         }
       }
     },
-    "Automatic checks paused" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatic checks paused"
+    "Automatic checks paused": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatic checks paused"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comprobaciones automáticas en pausa"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprobaciones automáticas en pausa"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vérifications automatiques en pause"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifications automatiques en pause"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Controlli automatici in pausa"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Controlli automatici in pausa"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificações automáticas em pausa"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificações automáticas em pausa"
           }
         }
       }
     },
-    "Available" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Available"
+    "Available": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Available"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disponible"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disponible"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disponible"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disponible"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disponibile"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disponibile"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disponível"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disponível"
           }
         }
       }
     },
-    "Available version" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Available version"
+    "Available version": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Available version"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version disponible"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version disponible"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version disponible"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version disponible"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versione disponibile"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versione disponibile"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versão disponível"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versão disponível"
           }
         }
       }
     },
-    "Back" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Back"
+    "Back": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atras"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atras"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retour"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retour"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Indietro"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indietro"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voltar"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voltar"
           }
         }
       }
     },
-    "Back to bottom" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retour en bas"
+    "Back to bottom": {
+      "extractionState": "stale",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retour en bas"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Torna in fondo"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Torna in fondo"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voltar ao final"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voltar ao final"
           }
         }
       }
     },
-    "Back to workspace" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Back to workspace"
+    "Back to workspace": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back to workspace"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Volver al espacio de trabajo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Volver al espacio de trabajo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retour à l'espace de travail"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retour à l'espace de travail"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Torna allo spazio di lavoro"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Torna allo spazio di lavoro"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voltar ao espaço de trabalho"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voltar ao espaço de trabalho"
           }
         }
       }
     },
-    "Background" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Background"
+    "Background": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Background"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fondo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fondo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arrière-plan"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrière-plan"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sfondo"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sfondo"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fundo"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fundo"
           }
         }
       }
     },
-    "Base surface color used to build canvas, panels, and cards." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Base surface color used to build canvas, panels, and cards."
+    "Base surface color used to build canvas, panels, and cards.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Base surface color used to build canvas, panels, and cards."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Color base de superficie usado para construir el lienzo, los paneles y las tarjetas."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color base de superficie usado para construir el lienzo, los paneles y las tarjetas."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couleur de surface de base utilisée pour construire la toile, les panneaux et les cartes."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couleur de surface de base utilisée pour construire la toile, les panneaux et les cartes."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Colore di superficie di base usato per costruire tela, pannelli e schede."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Colore di superficie di base usato per costruire tela, pannelli e schede."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cor de superfície base usada para construir a tela, painéis e cartões."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cor de superfície base usada para construir a tela, painéis e cartões."
           }
         }
       }
     },
-    "Branch" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Branch"
+    "Branch": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Branch"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rama"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rama"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Branche"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Branche"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Branch"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Branch"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ramo"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ramo"
           }
         }
       }
     },
-    "Branch name" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Branch name"
+    "Branch name": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Branch name"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nombre de la rama"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre de la rama"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nom de la branche"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nom de la branche"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nome branch"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome branch"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nome do ramo"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome do ramo"
           }
         }
       }
     },
-    "Build me a $1M SaaS. Make no mistakes." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Build me a $1M SaaS. Make no mistakes."
+    "Build me a $1M SaaS. Make no mistakes.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Build me a $1M SaaS. Make no mistakes."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Crea una SaaS de 1M$. No cometas errores."
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Crea una SaaS de 1M$. No cometas errores."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Construis-moi une SaaS à 1M$. Ne fais aucune erreur."
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Construis-moi une SaaS à 1M$. Ne fais aucune erreur."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Costruisci per me una SaaS da 1M$. Non sbagliare."
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Costruisci per me una SaaS da 1M$. Non sbagliare."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Crie uma SaaS de US$1M para mim. Não cometa erros."
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Crie uma SaaS de US$1M para mim. Não cometa erros."
           }
         }
       }
     },
-    "Build something cool" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Build something cool"
+    "Build something cool": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Build something cool"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Construye algo genial"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Construye algo genial"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Créez quelque chose de sympa"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Créez quelque chose de sympa"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Costruisci qualcosa di bello"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Costruisci qualcosa di bello"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Construa algo incrível"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Construa algo incrível"
           }
         }
       }
     },
-    "Cache" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cache"
+    "Cache": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cache"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cache"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cache"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cache"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cache"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cache"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cache"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cache"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cache"
           }
         }
       }
     },
-    "Cancel" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuler"
+    "Cancel": {
+      "extractionState": "stale",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annulla"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annulla"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         }
       }
     },
-    "Change the selected agent by name." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Change the selected agent by name."
+    "Change the selected agent by name.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Change the selected agent by name."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambia el agente seleccionado por nombre."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambia el agente seleccionado por nombre."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Changez l'agent sélectionné par nom."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changez l'agent sélectionné par nom."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modifica l'agente selezionato per nome."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifica l'agente selezionato per nome."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Altere o agente selecionado por nome."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Altere o agente selecionado por nome."
           }
         }
       }
     },
-    "Change the selected git branch." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Change the selected git branch."
+    "Change the selected git branch.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Change the selected git branch."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambia la rama de git seleccionada."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambia la rama de git seleccionada."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Changez la branche Git sélectionnée."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changez la branche Git sélectionnée."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambia il branch Git selezionato."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambia il branch Git selezionato."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Altere o ramo Git selecionado."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Altere o ramo Git selecionado."
           }
         }
       }
     },
-    "Change the selected model by name, provider, or model id." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Change the selected model by name, provider, or model id."
+    "Change the selected model by name, provider, or model id.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Change the selected model by name, provider, or model id."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambia el modelo seleccionado por nombre, proveedor o identificador."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambia el modelo seleccionado por nombre, proveedor o identificador."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Changez le modèle sélectionné par nom, fournisseur ou identifiant du modèle."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changez le modèle sélectionné par nom, fournisseur ou identifiant du modèle."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambia il modello selezionato per nome, provider o ID del modello."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambia il modello selezionato per nome, provider o ID del modello."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Altere o modelo selecionado por nome, provedor ou ID do modelo."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Altere o modelo selecionado por nome, provedor ou ID do modelo."
           }
         }
       }
     },
-    "Changes" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Changes"
+    "Changes": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changes"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambios"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambios"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modifications"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifications"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modifiche"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifiche"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alterações"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alterações"
           }
         }
       }
     },
-    "Changes the base size used across labels, headers, and controls." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Changes the base size used across labels, headers, and controls."
+    "Changes the base size used across labels, headers, and controls.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changes the base size used across labels, headers, and controls."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambia el tamano base usado en etiquetas, encabezados y controles."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambia el tamano base usado en etiquetas, encabezados y controles."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modifie la taille de base utilisée pour les étiquettes, les en-têtes et les contrôles."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifie la taille de base utilisée pour les étiquettes, les en-têtes et les contrôles."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modifica la dimensione base usata per etichette, intestazioni e controlli."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifica la dimensione base usata per etichette, intestazioni e controlli."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Altera o tamanho base usado em rótulos, cabeçalhos e controles."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Altera o tamanho base usado em rótulos, cabeçalhos e controles."
           }
         }
       }
     },
-    "Changes transcript, diff, and code-preview sizing throughout the app." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Changes transcript, diff, and code-preview sizing throughout the app."
+    "Changes transcript, diff, and code-preview sizing throughout the app.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changes transcript, diff, and code-preview sizing throughout the app."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambia el tamano de las transcripciones, los diff y las vistas previas de codigo en toda la app."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambia el tamano de las transcripciones, los diff y las vistas previas de codigo en toda la app."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modifie les tailles de la transcription, des diffs et des aperçus de code dans l'application."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifie les tailles de la transcription, des diffs et des aperçus de code dans l'application."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modifica le dimensioni della trascrizione, dei diff e dell'anteprima del codice in tutta l'app."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifica le dimensioni della trascrizione, dei diff e dell'anteprima del codice in tutta l'app."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Altera o dimensionamento de transcrição, diff e prévia de código em todo o app."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Altera o dimensionamento de transcrição, diff e prévia de código em todo o app."
           }
         }
       }
     },
-    "Check manually" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Check manually"
+    "Check manually": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check manually"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comprobar manualmente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprobar manualmente"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vérifier manuellement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifier manuellement"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Controlla manualmente"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Controlla manualmente"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificar manualmente"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificar manualmente"
           }
         }
       }
     },
-    "Check now" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Check now"
+    "Check now": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check now"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comprobar ahora"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprobar ahora"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vérifier maintenant"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifier maintenant"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verifica ora"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifica ora"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificar agora"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificar agora"
           }
         }
       }
     },
-    "Checking" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Checking"
+    "Checking": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Checking"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comprobando"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprobando"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vérification"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérification"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verifica"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifica"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificando"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificando"
           }
         }
       }
     },
-    "Checking now" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Checking now"
+    "Checking now": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Checking now"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comprobando ahora"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprobando ahora"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vérification en cours"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérification en cours"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Controllo in corso"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Controllo in corso"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificando agora"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificando agora"
           }
         }
       }
     },
-    "Checking…" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Checking…"
+    "Checking…": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Checking…"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comprobando…"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprobando…"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vérification…"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérification…"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verifica…"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifica…"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificando…"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificando…"
           }
         }
       }
     },
-    "Choose how NeoCode opens and which app should handle projects before a workspace-specific override takes over." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choose how NeoCode opens and which app should handle projects before a workspace-specific override takes over."
+    "Choose how NeoCode opens and which app should handle projects before a workspace-specific override takes over.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose how NeoCode opens and which app should handle projects before a workspace-specific override takes over."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elige como se abre NeoCode y que app debe manejar los proyectos antes de aplicar una preferencia especifica del espacio de trabajo."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige como se abre NeoCode y que app debe manejar los proyectos antes de aplicar una preferencia especifica del espacio de trabajo."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choisissez comment NeoCode s'ouvre et quelle application doit gérer les projets avant qu'une préférence par espace de travail ne prenne le relais."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisissez comment NeoCode s'ouvre et quelle application doit gérer les projets avant qu'une préférence par espace de travail ne prenne le relais."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scegli come NeoCode si apre e quale app dovrebbe gestire i progetti prima che intervenga un override specifico dello spazio di lavoro."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scegli come NeoCode si apre e quale app dovrebbe gestire i progetti prima che intervenga un override specifico dello spazio di lavoro."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escolha como o NeoCode abre e qual app deve lidar com os projetos antes que uma substituição específica do espaço de trabalho assuma."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escolha como o NeoCode abre e qual app deve lidar com os projetos antes que uma substituição específica do espaço de trabalho assuma."
           }
         }
       }
     },
-    "Choose whether NeoCode follows the system language or always uses a specific app language." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choose whether NeoCode follows the system language or always uses a specific app language."
+    "Choose whether NeoCode follows the system language or always uses a specific app language.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose whether NeoCode follows the system language or always uses a specific app language."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elige si NeoCode sigue el idioma del sistema o usa siempre un idioma concreto."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige si NeoCode sigue el idioma del sistema o usa siempre un idioma concreto."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choisissez si NeoCode suit la langue du système ou utilise toujours une langue d'application spécifique."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisissez si NeoCode suit la langue du système ou utilise toujours une langue d'application spécifique."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scegli se NeoCode segue la lingua di sistema o usa sempre una lingua specifica dell'app."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scegli se NeoCode segue la lingua di sistema o usa sempre una lingua specifica dell'app."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escolha se o NeoCode segue o idioma do sistema ou sempre usa um idioma específico do aplicativo."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escolha se o NeoCode segue o idioma do sistema ou sempre usa um idioma específico do aplicativo."
           }
         }
       }
     },
-    "Choose whether Return sends immediately or only Command-Return sends while Return inserts a newline." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choose whether Return sends immediately or only Command-Return sends while Return inserts a newline."
+    "Choose whether Return sends immediately or only Command-Return sends while Return inserts a newline.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose whether Return sends immediately or only Command-Return sends while Return inserts a newline."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elige si Retorno envia de inmediato o si solo Comando-Retorno envia mientras Retorno inserta una nueva linea."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige si Retorno envia de inmediato o si solo Comando-Retorno envia mientras Retorno inserta una nueva linea."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choisissez si Return envoie immédiatement ou si seul Command-Return envoie pendant que Return insère un saut de ligne."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisissez si Return envoie immédiatement ou si seul Command-Return envoie pendant que Return insère un saut de ligne."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scegli se Invio invia immediatamente o se solo Command-Invio invia mentre Invio inserisce una nuova riga."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scegli se Invio invia immediatamente o se solo Command-Invio invia mentre Invio inserisce una nuova riga."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escolha se Enter envia imediatamente ou se apenas Command-Enter envia enquanto Enter insere uma nova linha."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escolha se Enter envia imediatamente ou se apenas Command-Enter envia enquanto Enter insere uma nova linha."
           }
         }
       }
     },
-    "Code font" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Code font"
+    "Code font": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Code font"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fuente de codigo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fuente de codigo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Police de code"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Police de code"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Font codice"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Font codice"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fonte de código"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fonte de código"
           }
         }
       }
     },
-    "Code font size" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Code font size"
+    "Code font size": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Code font size"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tamano de fuente del codigo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamano de fuente del codigo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Taille de police de code"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taille de police de code"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dimensione font codice"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dimensione font codice"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tamanho da fonte de código"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamanho da fonte de código"
           }
         }
       }
     },
-    "Collapse project" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Collapse project"
+    "Collapse project": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collapse project"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contraer proyecto"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contraer proyecto"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Réduire le projet"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réduire le projet"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comprimi progetto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprimi progetto"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recolher projeto"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recolher projeto"
           }
         }
       }
     },
-    "Command-Return" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Command-Return"
+    "Command-Return": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Command-Return"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comando-Retorno"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comando-Retorno"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commande-Retour"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commande-Retour"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Command-Invio"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Command-Invio"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Command-Enter"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Command-Enter"
           }
         }
       }
     },
-    "Commit" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commit"
+    "Commit": {
+      "extractionState": "stale",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commit"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commit"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commit"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commit"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commit"
           }
         }
       }
     },
-    "Commit and create PR" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commit and create PR"
+    "Commit and create PR": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commit and create PR"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commit y crear PR"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commit y crear PR"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commit et créer une PR"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commit et créer une PR"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commit e crea PR"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commit e crea PR"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commit e criar PR"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commit e criar PR"
           }
         }
       }
     },
-    "Commit and push" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commit and push"
+    "Commit and push": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commit and push"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commit y push"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commit y push"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commit et push"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commit et push"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commit e push"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commit e push"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commit e push"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commit e push"
           }
         }
       }
     },
-    "Commit message" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commit message"
+    "Commit message": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commit message"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mensaje de commit"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mensaje de commit"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Message de commit"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Message de commit"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Messaggio di commit"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Messaggio di commit"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mensagem de commit"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mensagem de commit"
           }
         }
       }
     },
-    "Commit your changes" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commit your changes"
+    "Commit your changes": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commit your changes"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Haz commit de tus cambios"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haz commit de tus cambios"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commit vos modifications"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commit vos modifications"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commit delle tue modifiche"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commit delle tue modifiche"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commit suas alterações"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commit suas alterações"
           }
         }
       }
     },
-    "Committing" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Committing"
+    "Committing": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Committing"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Haciendo commit"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haciendo commit"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commit en cours"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commit en cours"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commit in corso"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commit in corso"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fazendo commit"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fazendo commit"
           }
         }
       }
     },
-    "Compact" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compact"
+    "Compact": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compact"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compactar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compactar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compacter"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compacter"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compatta"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compatta"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compactar"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compactar"
           }
         }
       }
     },
-    "Compact Session" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compact Session"
+    "Compact Session": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compact Session"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compactar sesion"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compactar sesion"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Session compacte"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Session compacte"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sessione compatta"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sessione compatta"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sessão compactada"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sessão compactada"
           }
         }
       }
     },
-    "Compaction summary" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compaction summary"
+    "Compaction summary": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compaction summary"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resumen de compactacion"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resumen de compactacion"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Résumé du compactage"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Résumé du compactage"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Riepilogo compattazione"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riepilogo compattazione"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resumo da compactação"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resumo da compactação"
           }
         }
       }
     },
-    "completed" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "completed"
+    "completed": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "completed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "completado"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "completado"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "terminé"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "terminé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "completato"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "completato"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "concluído"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "concluído"
           }
         }
       }
     },
-    "Composer" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Composer"
+    "Composer": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Composer"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compositor"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compositor"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compositeur"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compositeur"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compositore"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compositore"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compositor"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compositor"
           }
         }
       }
     },
-    "Confirm" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirm"
+    "Confirm": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirmar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirmar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirmer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirmer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conferma"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conferma"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirmar"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirmar"
           }
         }
       }
     },
-    "Context limit" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Context limit"
+    "Context limit": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Context limit"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limite de contexto"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limite de contexto"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limite de contexte"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limite de contexte"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limite di contesto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limite di contesto"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limite de contexto"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limite de contexto"
           }
         }
       }
     },
-    "Context limit unavailable" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Context limit unavailable"
+    "Context limit unavailable": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Context limit unavailable"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limite de contexto no disponible"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limite de contexto no disponible"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limite de contexte indisponible"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limite de contexte indisponible"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limite di contesto non disponibile"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limite di contesto non disponibile"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limite de contexto indisponível"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limite de contexto indisponível"
           }
         }
       }
     },
-    "Context remaining" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Context remaining"
+    "Context remaining": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Context remaining"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contexto restante"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contexto restante"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contexte restant"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contexte restant"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contesto rimanente"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contesto rimanente"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contexto restante"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contexto restante"
           }
         }
       }
     },
-    "Context used" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Context used"
+    "Context used": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Context used"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contexto usado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contexto usado"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contexte utilisé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contexte utilisé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contesto utilizzato"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contesto utilizzato"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contexto usado"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contexto usado"
           }
         }
       }
     },
-    "Continue" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continue"
+    "Continue": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continuar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continuer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continua"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continua"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continuar"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuar"
           }
         }
       }
     },
-    "Control whether NeoCode should remember safety-related per-thread behavior between launches." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Control whether NeoCode should remember safety-related per-thread behavior between launches."
+    "Control whether NeoCode should remember safety-related per-thread behavior between launches.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Control whether NeoCode should remember safety-related per-thread behavior between launches."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Controla si NeoCode debe recordar el comportamiento relacionado con la seguridad en cada hilo entre sesiones."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Controla si NeoCode debe recordar el comportamiento relacionado con la seguridad en cada hilo entre sesiones."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contrôlez si NeoCode doit mémoriser les comportements liés à la sécurité par conversation entre les lancements."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contrôlez si NeoCode doit mémoriser les comportements liés à la sécurité par conversation entre les lancements."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Controlla se NeoCode deve ricordare il comportamento per thread legato alla sicurezza tra un avvio e l'altro."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Controlla se NeoCode deve ricordare il comportamento per thread legato alla sicurezza tra un avvio e l'altro."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Controle se o NeoCode deve lembrar o comportamento por thread relacionado à segurança entre inicializações."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Controle se o NeoCode deve lembrar o comportamento por thread relacionado à segurança entre inicializações."
           }
         }
       }
     },
-    "Copied" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Copied"
+    "Copied": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copied"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Copiado"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copiado"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Copié"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copié"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Copiato"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copiato"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Copiado"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copiado"
           }
         }
       }
     },
-    "Copy message" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Copy message"
+    "Copy message": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy message"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Copiar mensaje"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copiar mensaje"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Copier le message"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copier le message"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Copia messaggio"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copia messaggio"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Copiar mensagem"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copiar mensagem"
           }
         }
       }
     },
-    "Copy theme" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copy theme"
+    "Copy theme": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy theme"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copiar tema"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar tema"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copier le thème"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copier le thème"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copia tema"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia tema"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copiar tema"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar tema"
           }
         }
       }
     },
-    "Cost" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cost"
+    "Cost": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cost"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Costo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Costo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Coût"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coût"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Costo"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Costo"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Custo"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Custo"
           }
         }
       }
     },
-    "Could not import theme JSON." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Could not import theme JSON."
+    "Could not import theme JSON.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not import theme JSON."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo importar el JSON del tema."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo importar el JSON del tema."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible d'importer le JSON du thème."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible d'importer le JSON du thème."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossibile importare il JSON del tema."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile importare il JSON del tema."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Não foi possível importar o JSON do tema."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foi possível importar o JSON do tema."
           }
         }
       }
     },
-    "Could not serialize the theme as JSON." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Could not serialize the theme as JSON."
+    "Could not serialize the theme as JSON.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not serialize the theme as JSON."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo serializar el tema como JSON."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo serializar el tema como JSON."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible de sérialiser le thème en JSON."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de sérialiser le thème en JSON."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossibile serializzare il tema come JSON."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile serializzare il tema come JSON."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Não foi possível serializar o tema como JSON."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foi possível serializar o tema como JSON."
           }
         }
       }
     },
-    "Create" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Create"
+    "Create": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crear"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crear"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Créer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Créer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crea"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crea"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Criar"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criar"
           }
         }
       }
     },
-    "Create a new branch for this session." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Create a new branch for this session."
+    "Create a new branch for this session.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create a new branch for this session."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crea una nueva rama para esta sesion."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crea una nueva rama para esta sesion."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Créez une nouvelle branche pour cette session."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Créez une nouvelle branche pour cette session."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crea un nuovo branch per questa sessione."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crea un nuovo branch per questa sessione."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crie um novo ramo para esta sessão."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crie um novo ramo para esta sessão."
           }
         }
       }
     },
-    "Create a new session. Add text after it to seed the new draft." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Create a new session. Add text after it to seed the new draft."
+    "Create a new session. Add text after it to seed the new draft.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create a new session. Add text after it to seed the new draft."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crea una nueva sesion. Anade texto despues para iniciar el nuevo borrador."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crea una nueva sesion. Anade texto despues para iniciar el nuevo borrador."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Créez une nouvelle session. Ajoutez du texte après pour amorcer le nouveau brouillon."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Créez une nouvelle session. Ajoutez du texte après pour amorcer le nouveau brouillon."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crea una nuova sessione. Aggiungi testo dopo per avviare la nuova bozza."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crea una nuova sessione. Aggiungi testo dopo per avviare la nuova bozza."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crie uma nova sessão. Adicione texto após ela para iniciar o novo rascunho."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crie uma nova sessão. Adicione texto após ela para iniciar o novo rascunho."
           }
         }
       }
     },
-    "Create a new thread or select one from the sidebar to begin chatting with the OpenCode runtime." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Créez une nouvelle conversation ou sélectionnez-en une dans la barre latérale pour commencer à discuter avec le runtime OpenCode."
+    "Create a new thread or select one from the sidebar to begin chatting with the OpenCode runtime.": {
+      "extractionState": "stale",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Créez une nouvelle conversation ou sélectionnez-en une dans la barre latérale pour commencer à discuter avec le runtime OpenCode."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crea una nuova conversazione o seleziona una dalla barra laterale per iniziare a chattare con il runtime OpenCode."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crea una nuova conversazione o seleziona una dalla barra laterale per iniziare a chattare con il runtime OpenCode."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crie uma nova conversa ou selecione uma na barra lateral para começar a conversar com o tempo de execução OpenCode."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crie uma nova conversa ou selecione uma na barra lateral para começar a conversar com o tempo de execução OpenCode."
           }
         }
       }
     },
-    "Create Branch" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Create Branch"
+    "Create Branch": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create Branch"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crear rama"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crear rama"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Créer une branche"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Créer une branche"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crea branch"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crea branch"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Criar ramo"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criar ramo"
           }
         }
       }
     },
-    "Create Branch..." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Create Branch..."
+    "Create Branch...": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create Branch..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crear rama..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crear rama..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Créer une branche..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Créer une branche..."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crea branch..."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crea branch..."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Criar ramo..."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criar ramo..."
           }
         }
       }
     },
-    "Create Git Repository" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Create Git Repository"
+    "Create Git Repository": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create Git Repository"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crear repositorio Git"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crear repositorio Git"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Créer un dépôt Git"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Créer un dépôt Git"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crea repository Git"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crea repository Git"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Criar repositório Git"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criar repositório Git"
           }
         }
       }
     },
-    "Create PR" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Create PR"
+    "Create PR": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create PR"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crear PR"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crear PR"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Créer une PR"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Créer une PR"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crea PR"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crea PR"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Criar PR"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criar PR"
           }
         }
       }
     },
-    "Creating" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creating"
+    "Creating": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creating"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creando"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creando"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Création"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Création"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creazione"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creazione"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Criando"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criando"
           }
         }
       }
     },
-    "Current" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Current"
+    "Current": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Current"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actual"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actual"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actuelle"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actuelle"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Attuale"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attuale"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atual"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atual"
           }
         }
       }
     },
-    "Current version" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Current version"
+    "Current version": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Current version"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version actual"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version actual"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version actuelle"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version actuelle"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versione attuale"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versione attuale"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versão atual"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versão atual"
           }
         }
       }
     },
-    "Custom" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Custom"
+    "Custom": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Custom"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Personalizado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personalizado"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Personnalisé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personnalisé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Personalizzato"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personalizzato"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Personalizado"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personalizado"
           }
         }
       }
     },
-    "Dark" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dark"
+    "Dark": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oscuro"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oscuro"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sombre"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sombre"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scuro"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scuro"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escuro"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escuro"
           }
         }
       }
     },
-    "Dark theme" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dark theme"
+    "Dark theme": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark theme"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tema oscuro"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tema oscuro"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thème sombre"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thème sombre"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tema scuro"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tema scuro"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tema escuro"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tema escuro"
           }
         }
       }
     },
-    "Dashboard" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dashboard"
+    "Dashboard": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dashboard"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Panel"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Panel"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tableau de bord"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tableau de bord"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dashboard"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dashboard"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Painel"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Painel"
           }
         }
       }
     },
-    "Dashboard range" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dashboard range"
+    "Dashboard range": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dashboard range"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rango del panel"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rango del panel"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Plage du tableau de bord"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plage du tableau de bord"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intervallo dashboard"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intervallo dashboard"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intervalo do painel"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intervalo do painel"
           }
         }
       }
     },
-    "Delete" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete"
+    "Delete": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eliminar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Supprimer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elimina"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elimina"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Excluir"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excluir"
           }
         }
       }
     },
-    "Deny" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deny"
+    "Deny": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deny"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Denegar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Denegar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Refuser"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refuser"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nega"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nega"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Negar"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Negar"
           }
         }
       }
     },
-    "Dismiss" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dismiss"
+    "Dismiss": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dismiss"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descartar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descartar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignorer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignorer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chiudi"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chiudi"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dispensar"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dispensar"
           }
         }
       }
     },
-    "Download %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download %@"
+    "Download %@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descargar %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargar %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Télécharger %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Télécharger %@"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scarica %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scarica %@"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Baixar %@"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Baixar %@"
           }
         }
       }
     },
-    "Download the new build now or finish installing the copy Sparkle has already staged." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download the new build now or finish installing the copy Sparkle has already staged."
+    "Download the new build now or finish installing the copy Sparkle has already staged.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download the new build now or finish installing the copy Sparkle has already staged."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descarga ahora la nueva compilacion o termina de instalar la copia que Sparkle ya preparo."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descarga ahora la nueva compilacion o termina de instalar la copia que Sparkle ya preparo."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Téléchargez la nouvelle build maintenant ou terminez l'installation de la copie déjà préparée par Sparkle."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Téléchargez la nouvelle build maintenant ou terminez l'installation de la copie déjà préparée par Sparkle."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scarica subito la nuova build oppure completa l'installazione della copia che Sparkle ha già preparato."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scarica subito la nuova build oppure completa l'installazione della copia che Sparkle ha già preparato."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Faça o download da nova compilação agora ou termine de instalar a cópia que o Sparkle já preparou."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Faça o download da nova compilação agora ou termine de instalar a cópia que o Sparkle já preparou."
           }
         }
       }
     },
-    "Downloading: %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Downloading: %@"
+    "Downloading: %@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Downloading: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descargando: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargando: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Téléchargement : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Téléchargement : %@"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scaricamento: %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scaricamento: %@"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Baixando: %@"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Baixando: %@"
           }
         }
       }
     },
-    "Edit" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modifier"
+    "Edit": {
+      "extractionState": "stale",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifier"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modifica"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifica"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Editar"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar"
           }
         }
       }
     },
-    "English" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "English"
+    "English": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ingles"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingles"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anglais"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anglais"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inglese"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inglese"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inglês"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inglês"
           }
         }
       }
     },
-    "Enter a commit message" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter a commit message"
+    "Enter a commit message": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a commit message"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escribe un mensaje de commit"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escribe un mensaje de commit"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entrez un message de commit"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entrez un message de commit"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inserisci un messaggio di commit"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inserisci un messaggio di commit"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Digite uma mensagem de commit"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Digite uma mensagem de commit"
           }
         }
       }
     },
-    "Error" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error"
+    "Error": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erreur"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erreur"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Errore"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Errore"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erro"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erro"
           }
         }
       }
     },
-    "Expand project" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Expand project"
+    "Expand project": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expand project"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Expandir proyecto"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expandir proyecto"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Développer le projet"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Développer le projet"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Espandi progetto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Espandi progetto"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Expandir projeto"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expandir projeto"
           }
         }
       }
     },
-    "failed" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "failed"
+    "failed": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "failed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "falló"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "falló"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "échec"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "échec"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "fallito"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "fallito"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "falhou"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "falhou"
           }
         }
       }
     },
-    "File changes that will be reverted" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "File changes that will be reverted"
+    "File changes that will be reverted": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File changes that will be reverted"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambios de archivos que se revertiran"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambios de archivos que se revertiran"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modifications de fichiers qui seront annulées"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifications de fichiers qui seront annulées"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modifiche ai file che verranno annullate"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifiche ai file che verranno annullate"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alterações em arquivo que serão revertidas"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alterações em arquivo que serão revertidas"
           }
         }
       }
     },
-    "File copied with no inline hunk details." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "File copied with no inline hunk details."
+    "File copied with no inline hunk details.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "File copied with no inline hunk details."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archivo copiado sin detalles de hunk en línea."
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Archivo copiado sin detalles de hunk en línea."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Fichier copié sans détails d'hunk en ligne."
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Fichier copié sans détails d'hunk en ligne."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "File copiato senza dettagli di hunk in linea."
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "File copiato senza dettagli di hunk in linea."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Arquivo copiado sem detalhes de hunk em linha."
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Arquivo copiado sem detalhes de hunk em linha."
           }
         }
       }
     },
-    "File removed." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "File removed."
+    "File removed.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "File removed."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archivo eliminado."
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Archivo eliminado."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Fichier supprimé."
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Fichier supprimé."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "File eliminato."
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "File eliminato."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Arquivo removido."
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Arquivo removido."
           }
         }
       }
     },
-    "File renamed with no inline hunk details." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "File renamed with no inline hunk details."
+    "File renamed with no inline hunk details.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "File renamed with no inline hunk details."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archivo renombrado sin detalles de hunk en línea."
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Archivo renombrado sin detalles de hunk en línea."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Fichier renommé sans détails d'hunk en ligne."
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Fichier renommé sans détails d'hunk en ligne."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "File rinominato senza dettagli di hunk in linea."
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "File rinominato senza dettagli di hunk in linea."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Arquivo renomeado sem detalhes de hunk em linha."
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Arquivo renomeado sem detalhes de hunk em linha."
           }
         }
       }
     },
-    "Files" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Files"
+    "Files": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Files"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Archivos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Archivos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fichiers"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fichiers"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "File"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arquivos"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arquivos"
           }
         }
       }
     },
-    "Filter range" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Filter range"
+    "Filter range": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filter range"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Filtrar rango"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtrar rango"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Plage de filtre"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plage de filtre"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intervallo filtro"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intervallo filtro"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Filtrar intervalo"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtrar intervalo"
           }
         }
       }
     },
-    "finished" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "finished"
+    "finished": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "finished"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "finalizado"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "finalizado"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "terminé"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "terminé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "terminato"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "terminato"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "finalizado"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "finalizado"
           }
         }
       }
     },
-    "Foreground" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Foreground"
+    "Foreground": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Foreground"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Primer plano"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Primer plano"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Premier plan"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Premier plan"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Primo piano"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Primo piano"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Primeiro plano"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Primeiro plano"
           }
         }
       }
     },
-    "Fork message" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Fork message"
+    "Fork message": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Fork message"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Bifurcar mensaje"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Bifurcar mensaje"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Bifurquer le message"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Bifurquer le message"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Biforcare il messaggio"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Biforcare il messaggio"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Bifurcar mensagem"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Bifurcar mensagem"
           }
         }
       }
     },
-    "French" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "French"
+    "French": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "French"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Frances"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frances"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Français"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Français"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Francese"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Francese"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Francês"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Francês"
           }
         }
       }
     },
-    "General" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "General"
+    "General": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "General"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "General"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "General"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Général"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Général"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Generale"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generale"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geral"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geral"
           }
         }
       }
     },
-    "Generating compacted session summary..." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Generating compacted session summary..."
+    "Generating compacted session summary...": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generating compacted session summary..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Generando resumen de la sesion compactada..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generando resumen de la sesion compactada..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Génération du résumé de session compactée..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Génération du résumé de session compactée..."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Generazione del riepilogo della sessione compatta..."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generazione del riepilogo della sessione compatta..."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gerando resumo de sessão compactada..."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerando resumo de sessão compactada..."
           }
         }
       }
     },
-    "Give this thread a new name." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Give this thread a new name."
+    "Give this thread a new name.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Give this thread a new name."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dale un nombre nuevo a este hilo."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dale un nombre nuevo a este hilo."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Donnez un nouveau nom à cette conversation."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Donnez un nouveau nom à cette conversation."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dai un nuovo nome a questa conversazione."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dai un nuovo nome a questa conversazione."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dê um novo nome a esta conversa."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dê um novo nome a esta conversa."
           }
         }
       }
     },
-    "Idle" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Idle"
+    "Idle": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idle"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "En espera"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En espera"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inactif"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inactif"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inattivo"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inattivo"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inativo"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inativo"
           }
         }
       }
     },
-    "Import" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Import"
+    "Import": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importa"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importa"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importar"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar"
           }
         }
       }
     },
-    "Include unstaged" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Include unstaged"
+    "Include unstaged": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Include unstaged"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Incluir no preparados"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incluir no preparados"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inclure non préparés"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inclure non préparés"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Includi non staged"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Includi non staged"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Incluir não preparados"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incluir não preparados"
           }
         }
       }
     },
-    "Initializing Git" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Initializing Git"
+    "Initializing Git": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Initializing Git"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inicializando Git"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicializando Git"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Initialisation de Git"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Initialisation de Git"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inizializzazione di Git"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inizializzazione di Git"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inicializando Git"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicializando Git"
           }
         }
       }
     },
-    "Input" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Input"
+    "Input": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Input"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entrada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entrada"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entrée"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entrée"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Input"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Input"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entrada"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entrada"
           }
         }
       }
     },
-    "Install %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install %@"
+    "Install %@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Install %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalar %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalar %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installer %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installer %@"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installa %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installa %@"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalar %@"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalar %@"
           }
         }
       }
     },
-    "Install update %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install update %@"
+    "Install update %@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Install update %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalar actualización %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalar actualización %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installer la mise à jour %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installer la mise à jour %@"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installa aggiornamento %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installa aggiornamento %@"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalar atualização %@"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalar atualização %@"
           }
         }
       }
     },
-    "Installing %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installing %@"
+    "Installing %@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installing %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalando %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalando %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installation de %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installation de %@"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installazione di %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installazione di %@"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalando %@"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalando %@"
           }
         }
       }
     },
-    "Interface" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Interface"
+    "Interface": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interface"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Interfaz"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interfaz"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Interface"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interface"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Interfaccia"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interfaccia"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Interface"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interface"
           }
         }
       }
     },
-    "Italian" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Italian"
+    "Italian": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Italian"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Italiano"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Italiano"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Italien"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Italien"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Italiano"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Italiano"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Italiano"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Italiano"
           }
         }
       }
     },
-    "Keep long-running work alive and optionally notify you when NeoCode finishes or needs your input." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keep long-running work alive and optionally notify you when NeoCode finishes or needs your input."
+    "Keep long-running work alive and optionally notify you when NeoCode finishes or needs your input.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep long-running work alive and optionally notify you when NeoCode finishes or needs your input."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mantiene activas las tareas largas y, si quieres, te avisa cuando NeoCode termina o necesita tu entrada."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantiene activas las tareas largas y, si quieres, te avisa cuando NeoCode termina o necesita tu entrada."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Maintenez les tâches longues en cours et, si nécessaire, notifiez-vous lorsque NeoCode termine ou a besoin de votre intervention."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maintenez les tâches longues en cours et, si nécessaire, notifiez-vous lorsque NeoCode termine ou a besoin de votre intervention."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mantieni il lavoro a lunga durata attivo e facci sapere quando NeoCode finisce o necessita del tuo input."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantieni il lavoro a lunga durata attivo e facci sapere quando NeoCode finisce o necessita del tuo input."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mantenha trabalhos de longa duração ativos e, opcionalmente, notifique quando o NeoCode terminar ou precisar da sua entrada."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantenha trabalhos de longa duração ativos e, opcionalmente, notifique quando o NeoCode terminar ou precisar da sua entrada."
           }
         }
       }
     },
-    "Keep unfinished prompt text tied to each thread so you can move around the app without losing context." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keep unfinished prompt text tied to each thread so you can move around the app without losing context."
+    "Keep unfinished prompt text tied to each thread so you can move around the app without losing context.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep unfinished prompt text tied to each thread so you can move around the app without losing context."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mantiene el texto de los prompts sin terminar vinculado a cada hilo para que puedas moverte por la app sin perder contexto."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantiene el texto de los prompts sin terminar vinculado a cada hilo para que puedas moverte por la app sin perder contexto."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conservez le texte de prompt inachevé pour chaque conversation afin de naviguer dans l'app sans perdre le contexte."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conservez le texte de prompt inachevé pour chaque conversation afin de naviguer dans l'app sans perdre le contexte."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mantieni il testo del prompt incompleto legato a ogni conversazione così puoi muoverti nell'app senza perdere il contesto."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantieni il testo del prompt incompleto legato a ogni conversazione così puoi muoverti nell'app senza perdere il contesto."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mantenha o texto de prompt inacabado vinculado a cada conversa para poder navegar pelo app sem perder o contexto."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantenha o texto de prompt inacabado vinculado a cada conversa para poder navegar pelo app sem perder o contexto."
           }
         }
       }
     },
-    "Language" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Language"
+    "Language": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Language"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Idioma"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idioma"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Langue"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Langue"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lingua"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lingua"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Idioma"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idioma"
           }
         }
       }
     },
-    "Last 7 days" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Last 7 days"
+    "Last 7 days": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last 7 days"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ultimos 7 dias"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ultimos 7 dias"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "7 derniers jours"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7 derniers jours"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ultimi 7 giorni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ultimi 7 giorni"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Últimos 7 dias"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Últimos 7 dias"
           }
         }
       }
     },
-    "Last 30 days" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Last 30 days"
+    "Last 30 days": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last 30 days"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ultimos 30 dias"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ultimos 30 dias"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30 derniers jours"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 derniers jours"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ultimi 30 giorni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ultimi 30 giorni"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Últimos 30 dias"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Últimos 30 dias"
           }
         }
       }
     },
-    "Last 90 days" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Last 90 days"
+    "Last 90 days": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last 90 days"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ultimos 90 dias"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ultimos 90 dias"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "90 derniers jours"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "90 derniers jours"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ultimi 90 giorni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ultimi 90 giorni"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Últimos 90 dias"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Últimos 90 dias"
           }
         }
       }
     },
-    "Last activity" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Last activity"
+    "Last activity": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last activity"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ultima actividad"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ultima actividad"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dernière activité"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dernière activité"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ultima attività"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ultima attività"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Última atividade"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Última atividade"
           }
         }
       }
     },
-    "Last activity %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Last activity %@"
+    "Last activity %@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last activity %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ultima actividad %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ultima actividad %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dernière activité %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dernière activité %@"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ultima attività %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ultima attività %@"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Última atividade %@"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Última atividade %@"
           }
         }
       }
     },
-    "Last checked" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Last checked"
+    "Last checked": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last checked"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ultima comprobacion"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ultima comprobacion"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dernière vérification"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dernière vérification"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ultimo controllo"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ultimo controllo"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Última verificação"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Última verificação"
           }
         }
       }
     },
-    "Last request" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Last request"
+    "Last request": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last request"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ultima solicitud"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ultima solicitud"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dernière requête"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dernière requête"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ultima richiesta"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ultima richiesta"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Última solicitação"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Última solicitação"
           }
         }
       }
     },
-    "Last workspace" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Last workspace"
+    "Last workspace": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last workspace"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ultimo espacio de trabajo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ultimo espacio de trabajo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dernier espace de travail"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dernier espace de travail"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ultimo spazio di lavoro"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ultimo spazio di lavoro"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Último espaço de trabalho"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Último espaço de trabalho"
           }
         }
       }
     },
-    "Let Sparkle keep an eye on the release feed and raise the blue titlebar control when a newer signed build appears." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Let Sparkle keep an eye on the release feed and raise the blue titlebar control when a newer signed build appears."
+    "Let Sparkle keep an eye on the release feed and raise the blue titlebar control when a newer signed build appears.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Let Sparkle keep an eye on the release feed and raise the blue titlebar control when a newer signed build appears."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permite que Sparkle vigile el feed de versiones y muestre el control azul en la barra de titulo cuando aparezca una compilacion firmada mas reciente."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permite que Sparkle vigile el feed de versiones y muestre el control azul en la barra de titulo cuando aparezca una compilacion firmada mas reciente."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Laissez Sparkle surveiller le flux de releases et relever le contrôle bleu de la barre de titre lorsqu'une build signée plus récente apparaît."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Laissez Sparkle surveiller le flux de releases et relever le contrôle bleu de la barre de titre lorsqu'une build signée plus récente apparaît."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lascia che Sparkle tenga d'occhio il feed delle release e sollevi il controllo blu della barra del titolo quando appare una build firmata più recente."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lascia che Sparkle tenga d'occhio il feed delle release e sollevi il controllo blu della barra del titolo quando appare una build firmata più recente."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deixe o Sparkle observar o feed de lançamentos e levantar o controle azul da barra de título quando uma nova compilação assinada aparecer."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deixe o Sparkle observar o feed de lançamentos e levantar o controle azul da barra de título quando uma nova compilação assinada aparecer."
           }
         }
       }
     },
-    "Light" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Light"
+    "Light": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Light"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Claro"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claro"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clair"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clair"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chiaro"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chiaro"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Claro"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claro"
           }
         }
       }
     },
-    "Light theme" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Light theme"
+    "Light theme": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Light theme"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tema claro"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tema claro"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thème clair"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thème clair"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tema chiaro"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tema chiaro"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tema claro"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tema claro"
           }
         }
       }
     },
-    "Load older messages" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Load older messages"
+    "Load older messages": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Load older messages"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cargar mensajes anteriores"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargar mensajes anteriores"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Charger les messages plus anciens"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Charger les messages plus anciens"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Carica messaggi precedenti"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carica messaggi precedenti"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Carregar mensagens mais antigas"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carregar mensagens mais antigas"
           }
         }
       }
     },
-    "Loading older messages..." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading older messages..."
+    "Loading older messages...": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading older messages..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cargando mensajes anteriores..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando mensajes anteriores..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chargement des messages plus anciens..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chargement des messages plus anciens..."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Caricamento dei messaggi precedenti..."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Caricamento dei messaggi precedenti..."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Carregando mensagens mais antigas..."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carregando mensagens mais antigas..."
           }
         }
       }
     },
-    "Loading prompt..." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading prompt..."
+    "Loading prompt...": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading prompt..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cargando prompt..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando prompt..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chargement du prompt..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chargement du prompt..."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Caricamento del prompt..."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Caricamento del prompt..."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Carregando prompt..."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carregando prompt..."
           }
         }
       }
     },
-    "Low-glare palette for the main NeoCode shell." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Low-glare palette for the main NeoCode shell."
+    "Low-glare palette for the main NeoCode shell.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Low-glare palette for the main NeoCode shell."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Paleta de bajo brillo para la interfaz principal de NeoCode."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paleta de bajo brillo para la interfaz principal de NeoCode."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Palette à faible éblouissement pour le shell principal de NeoCode."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Palette à faible éblouissement pour le shell principal de NeoCode."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Palette a basso abbagliamento per la shell principale di NeoCode."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Palette a basso abbagliamento per la shell principale di NeoCode."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Paleta de baixo brilho para o shell principal do NeoCode."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paleta de baixo brilho para o shell principal do NeoCode."
           }
         }
       }
     },
-    "Messages" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Messages"
+    "Messages": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Messages"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mensajes"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mensajes"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Messages"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Messages"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Messaggi"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Messaggi"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mensagens"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mensagens"
           }
         }
       }
     },
-    "Model" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Model"
+    "Model": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Model"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modelo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modèle"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modèle"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modello"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modello"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modelo"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelo"
           }
         }
       }
     },
-    "Model usage distribution across categories" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Model usage distribution across categories"
+    "Model usage distribution across categories": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Model usage distribution across categories"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Distribucion de uso de modelos por categorias"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Distribucion de uso de modelos por categorias"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Répartition de l'utilisation des modèles par catégorie"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Répartition de l'utilisation des modèles par catégorie"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Distribuzione dell'uso dei modelli per categoria"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Distribuzione dell'uso dei modelli per categoria"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Distribuição do uso de modelos por categoria"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Distribuição do uso de modelos por categoria"
           }
         }
       }
     },
-    "More actions" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "More actions"
+    "More actions": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "More actions"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mas acciones"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mas acciones"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Plus d'actions"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plus d'actions"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Altre azioni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Altre azioni"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mais ações"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mais ações"
           }
         }
       }
     },
-    "Most frequently used tools" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Most frequently used tools"
+    "Most frequently used tools": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Most frequently used tools"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Herramientas usadas con mas frecuencia"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Herramientas usadas con mas frecuencia"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Outils les plus utilisés"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Outils les plus utilisés"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Strumenti più frequentemente usati"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Strumenti più frequentemente usati"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ferramentas mais usadas com frequência"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ferramentas mais usadas com frequência"
           }
         }
       }
     },
-    "Most Used Models" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Most Used Models"
+    "Most Used Models": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Most Used Models"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modelos mas usados"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelos mas usados"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modèles les plus utilisés"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modèles les plus utilisés"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modelli più usati"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelli più usati"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modelos mais usados"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelos mais usados"
           }
         }
       }
     },
-    "needs input" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "needs input"
+    "needs input": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "needs input"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "requiere entrada"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "requiere entrada"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "requiert une saisie"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "requiert une saisie"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "richiede input"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "richiede input"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "precisa de entrada"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "precisa de entrada"
           }
         }
       }
     },
-    "NeoCode checks signed GitHub releases in the background and surfaces new versions in the titlebar instead of interrupting your flow with a modal window." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "NeoCode checks signed GitHub releases in the background and surfaces new versions in the titlebar instead of interrupting your flow with a modal window."
+    "NeoCode checks signed GitHub releases in the background and surfaces new versions in the titlebar instead of interrupting your flow with a modal window.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NeoCode checks signed GitHub releases in the background and surfaces new versions in the titlebar instead of interrupting your flow with a modal window."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "NeoCode comprueba en segundo plano las versiones firmadas de GitHub y muestra las nuevas versiones en la barra de titulo en lugar de interrumpirte con una ventana modal."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NeoCode comprueba en segundo plano las versiones firmadas de GitHub y muestra las nuevas versiones en la barra de titulo en lugar de interrumpirte con una ventana modal."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "NeoCode vérifie en arrière-plan les releases signées GitHub et affiche les nouvelles versions dans la barre de titre au lieu d'interrompre votre flux avec une fenêtre modale."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NeoCode vérifie en arrière-plan les releases signées GitHub et affiche les nouvelles versions dans la barre de titre au lieu d'interrompre votre flux avec une fenêtre modale."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "NeoCode controlla in background le release firmate su GitHub e mostra le nuove versioni nella barra del titolo invece di interrompere il flusso con una finestra modale."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NeoCode controlla in background le release firmate su GitHub e mostra le nuove versioni nella barra del titolo invece di interrompere il flusso con una finestra modale."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O NeoCode verifica lançamentos assinados do GitHub em segundo plano e apresenta novas versões na barra de título em vez de interromper seu fluxo com uma janela modal."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O NeoCode verifica lançamentos assinados do GitHub em segundo plano e apresenta novas versões na barra de título em vez de interromper seu fluxo com uma janela modal."
           }
         }
       }
     },
-    "NeoCode is downloading version %@. The titlebar control mirrors the live percentage so you can keep working." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "NeoCode is downloading version %@. The titlebar control mirrors the live percentage so you can keep working."
+    "NeoCode is downloading version %@. The titlebar control mirrors the live percentage so you can keep working.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NeoCode is downloading version %@. The titlebar control mirrors the live percentage so you can keep working."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "NeoCode está descargando la versión %@. El control de la barra de título refleja el porcentaje en directo para que puedas seguir trabajando."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NeoCode está descargando la versión %@. El control de la barra de título refleja el porcentaje en directo para que puedas seguir trabajando."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "NeoCode télécharge la version %@. Le contrôle dans la barre de titre reflète le pourcentage en direct afin que vous puissiez continuer à travailler."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NeoCode télécharge la version %@. Le contrôle dans la barre de titre reflète le pourcentage en direct afin que vous puissiez continuer à travailler."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "NeoCode sta scaricando la versione %@. Il controllo nella barra del titolo mostra la percentuale in tempo reale così puoi continuare a lavorare."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NeoCode sta scaricando la versione %@. Il controllo nella barra del titolo mostra la percentuale in tempo reale così puoi continuare a lavorare."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O NeoCode está baixando a versão %@. O controle na barra de título reflete a porcentagem ao vivo para que você possa continuar trabalhando."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O NeoCode está baixando a versão %@. O controle na barra de título reflete a porcentagem ao vivo para que você possa continuar trabalhando."
           }
         }
       }
     },
-    "NeoCode is scanning your tracked projects and building a reusable usage cache. As soon as the first summaries land, they will appear here." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "NeoCode is scanning your tracked projects and building a reusable usage cache. As soon as the first summaries land, they will appear here."
+    "NeoCode is scanning your tracked projects and building a reusable usage cache. As soon as the first summaries land, they will appear here.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NeoCode is scanning your tracked projects and building a reusable usage cache. As soon as the first summaries land, they will appear here."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "NeoCode esta escaneando tus proyectos seguidos y construyendo una cache reutilizable de uso. En cuanto lleguen los primeros resumenes, apareceran aqui."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NeoCode esta escaneando tus proyectos seguidos y construyendo una cache reutilizable de uso. En cuanto lleguen los primeros resumenes, apareceran aqui."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "NeoCode analyse vos projets suivis et construit un cache d'utilisation réutilisable. Dès l'arrivée des premiers résumés, ils apparaîtront ici."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NeoCode analyse vos projets suivis et construit un cache d'utilisation réutilisable. Dès l'arrivée des premiers résumés, ils apparaîtront ici."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "NeoCode sta scansionando i progetti monitorati e costruendo una cache di utilizzo riutilizzabile. Appena arrivano i primi riepiloghi, compariranno qui."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NeoCode sta scansionando i progetti monitorati e costruendo una cache di utilizzo riutilizzabile. Appena arrivano i primi riepiloghi, compariranno qui."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O NeoCode está escaneando seus projetos rastreados e construindo um cache de uso reutilizável. Assim que os primeiros resumos chegarem, eles aparecerão aqui."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O NeoCode está escaneando seus projetos rastreados e construindo um cache de uso reutilizável. Assim que os primeiros resumos chegarem, eles aparecerão aqui."
           }
         }
       }
     },
-    "NeoCode keeps a historical usage cache so the dashboard can load instantly on future launches and only refresh the sessions that changed." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "NeoCode keeps a historical usage cache so the dashboard can load instantly on future launches and only refresh the sessions that changed."
+    "NeoCode keeps a historical usage cache so the dashboard can load instantly on future launches and only refresh the sessions that changed.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NeoCode keeps a historical usage cache so the dashboard can load instantly on future launches and only refresh the sessions that changed."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "NeoCode mantiene una cache historica de uso para que el panel cargue al instante en futuros inicios y solo refresque las sesiones que cambiaron."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NeoCode mantiene una cache historica de uso para que el panel cargue al instante en futuros inicios y solo refresque las sesiones que cambiaron."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "NeoCode conserve un cache d'utilisation historique pour que le tableau de bord se charge instantanément lors des prochains lancements et ne recharge que les sessions modifiées."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NeoCode conserve un cache d'utilisation historique pour que le tableau de bord se charge instantanément lors des prochains lancements et ne recharge que les sessions modifiées."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "NeoCode mantiene una cache storica dell'utilizzo in modo che la dashboard si carichi istantaneamente ai successivi avvii aggiornando solo le sessioni modificate."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NeoCode mantiene una cache storica dell'utilizzo in modo che la dashboard si carichi istantaneamente ai successivi avvii aggiornando solo le sessioni modificate."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O NeoCode mantém um cache histórico de uso para que o painel carregue instantaneamente em futuras inicializações e apenas atualize as sessões que mudaram."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O NeoCode mantém um cache histórico de uso para que o painel carregue instantaneamente em futuras inicializações e apenas atualize as sessões que mudaram."
           }
         }
       }
     },
-    "Never" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Never"
+    "Never": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Never"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nunca"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nunca"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jamais"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jamais"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mai"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mai"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nunca"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nunca"
           }
         }
       }
     },
-    "New file created." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New file created."
+    "New file created.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New file created."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Nuevo archivo creado."
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Nuevo archivo creado."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Nouveau fichier créé."
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Nouveau fichier créé."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Nuovo file creato."
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Nuovo file creato."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Novo arquivo criado."
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Novo arquivo criado."
           }
         }
       }
     },
-    "Next question" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Next question"
+    "Next question": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next question"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Siguiente pregunta"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Siguiente pregunta"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Question suivante"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Question suivante"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Domanda successiva"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domanda successiva"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Próxima pergunta"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Próxima pergunta"
           }
         }
       }
     },
-    "Next steps" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Next steps"
+    "Next steps": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next steps"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Siguientes pasos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Siguientes pasos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prochaines étapes"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prochaines étapes"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prossimi passaggi"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prossimi passaggi"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Próximos passos"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Próximos passos"
           }
         }
       }
     },
-    "No activity" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No activity"
+    "No activity": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No activity"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sin actividad"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin actividad"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune activité"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune activité"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessuna attività"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessuna attività"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sem atividade"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sem atividade"
           }
         }
       }
     },
-    "No added or removed lines." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No added or removed lines."
+    "No added or removed lines.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No added or removed lines."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No hay líneas añadidas ni eliminadas."
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No hay líneas añadidas ni eliminadas."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Aucune ligne ajoutée ou supprimée."
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Aucune ligne ajoutée ou supprimée."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Nessuna riga aggiunta o rimossa."
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Nessuna riga aggiunta o rimossa."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Nenhuma linha adicionada ou removida."
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Nenhuma linha adicionada ou removida."
           }
         }
       }
     },
-    "No agents available." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No agents available."
+    "No agents available.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No agents available."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No hay agentes disponibles."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay agentes disponibles."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucun agent disponible."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun agent disponible."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessun agente disponibile."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun agente disponibile."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhum agente disponível."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum agente disponível."
           }
         }
       }
     },
-    "No apps found." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No apps found."
+    "No apps found.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No apps found."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se encontraron apps."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontraron apps."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune application trouvée."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune application trouvée."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessuna app trovata."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessuna app trovata."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhum aplicativo encontrado."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum aplicativo encontrado."
           }
         }
       }
     },
-    "No assistant usage has been cached yet." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No assistant usage has been cached yet."
+    "No assistant usage has been cached yet.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No assistant usage has been cached yet."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aun no se ha almacenado en cache uso del asistente."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aun no se ha almacenado en cache uso del asistente."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune utilisation de l'assistant n'a encore été mise en cache."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune utilisation de l'assistant n'a encore été mise en cache."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ancora nessun utilizzo dell'assistente è stato memorizzato nella cache."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ancora nessun utilizzo dell'assistente è stato memorizzato nella cache."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhum uso do assistente foi armazenado em cache ainda."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum uso do assistente foi armazenado em cache ainda."
           }
         }
       }
     },
-    "No branches found." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No branches found."
+    "No branches found.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No branches found."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se encontraron ramas."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontraron ramas."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune branche trouvée."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune branche trouvée."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessun branch trovato."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun branch trovato."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhum ramo encontrado."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum ramo encontrado."
           }
         }
       }
     },
-    "No fonts found." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No fonts found."
+    "No fonts found.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No fonts found."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se encontraron fuentes."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontraron fuentes."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune police trouvée."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune police trouvée."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessun font trovato."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun font trovato."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhuma fonte encontrada."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhuma fonte encontrada."
           }
         }
       }
     },
-    "No languages found." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No languages found."
+    "No languages found.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No languages found."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se encontraron idiomas."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontraron idiomas."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune langue trouvée."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune langue trouvée."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessuna lingua trovata."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessuna lingua trovata."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhum idioma encontrado."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum idioma encontrado."
           }
         }
       }
     },
-    "No matching files." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No matching files."
+    "No matching files.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No matching files."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No hay archivos que coincidan."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay archivos que coincidan."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucun fichier correspondant."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun fichier correspondant."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessun file corrispondente."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun file corrispondente."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhum arquivo correspondente."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum arquivo correspondente."
           }
         }
       }
     },
-    "No matching slash commands." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No matching slash commands."
+    "No matching slash commands.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No matching slash commands."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No hay comandos slash que coincidan."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay comandos slash que coincidan."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune commande slash correspondante."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune commande slash correspondante."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessun comando slash corrispondente."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun comando slash corrispondente."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhum comando de barra correspondente."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum comando de barra correspondente."
           }
         }
       }
     },
-    "No models found." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No models found."
+    "No models found.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No models found."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se encontraron modelos."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontraron modelos."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucun modèle trouvé."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun modèle trouvé."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessun modello trovato."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun modello trovato."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhum modelo encontrado."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum modelo encontrado."
           }
         }
       }
     },
-    "No monospaced fonts found." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No monospaced fonts found."
+    "No monospaced fonts found.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No monospaced fonts found."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se encontraron fuentes monoespaciadas."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontraron fuentes monoespaciadas."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune police monospace trouvée."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune police monospace trouvée."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessun font monospace trovato."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun font monospace trovato."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhuma fonte monoespaçada encontrada."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhuma fonte monoespaçada encontrada."
           }
         }
       }
     },
-    "No projects yet" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No projects yet"
+    "No projects yet": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No projects yet"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aun no hay proyectos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aun no hay proyectos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucun projet encore"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun projet encore"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessun progetto ancora"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun progetto ancora"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhum projeto ainda"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum projeto ainda"
           }
         }
       }
     },
-    "No ranges available." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No ranges available."
+    "No ranges available.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No ranges available."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No hay rangos disponibles."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay rangos disponibles."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune plage disponible."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune plage disponible."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessun intervallo disponibile."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun intervallo disponibile."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhum intervalo disponível."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum intervalo disponível."
           }
         }
       }
     },
-    "No staged files are ready to commit." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No staged files are ready to commit."
+    "No staged files are ready to commit.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No staged files are ready to commit."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No hay archivos preparados listos para hacer commit."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay archivos preparados listos para hacer commit."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucun fichier préparé n'est prêt à être commité."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun fichier préparé n'est prêt à être commité."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessun file staged è pronto per il commit."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun file staged è pronto per il commit."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhum arquivo preparado está pronto para commit."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum arquivo preparado está pronto para commit."
           }
         }
       }
     },
-    "No tool activity has been cached yet." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No tool activity has been cached yet."
+    "No tool activity has been cached yet.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No tool activity has been cached yet."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aun no se ha almacenado en cache actividad de herramientas."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aun no se ha almacenado en cache actividad de herramientas."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune activité d'outil n'a encore été mise en cache."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune activité d'outil n'a encore été mise en cache."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessuna attività strumento è stata ancora memorizzata nella cache."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessuna attività strumento è stata ancora memorizzata nella cache."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhuma atividade de ferramenta foi armazenada em cache ainda."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhuma atividade de ferramenta foi armazenada em cache ainda."
           }
         }
       }
     },
-    "No tracked projects are ready yet." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No tracked projects are ready yet."
+    "No tracked projects are ready yet.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No tracked projects are ready yet."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aun no hay proyectos seguidos listos."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aun no hay proyectos seguidos listos."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucun projet suivi n'est encore prêt."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun projet suivi n'est encore prêt."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessun progetto tracciato è ancora pronto."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun progetto tracciato è ancora pronto."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhum projeto rastreado está pronto ainda."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum projeto rastreado está pronto ainda."
           }
         }
       }
     },
-    "No variants available." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No variants available."
+    "No variants available.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No variants available."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No hay variantes disponibles."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay variantes disponibles."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune variante disponible."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune variante disponible."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessuna variante disponibile."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessuna variante disponibile."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhuma variante disponível."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhuma variante disponível."
           }
         }
       }
     },
-    "Not answered yet" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Not answered yet"
+    "Not answered yet": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not answered yet"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aún sin responder"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aún sin responder"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pas encore répondu"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pas encore répondu"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Non ancora risposta"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non ancora risposta"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ainda sem resposta"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ainda sem resposta"
           }
         }
       }
     },
-    "Notify when a response finishes" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notify when a response finishes"
+    "Notify when a response finishes": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notify when a response finishes"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notificar cuando termina una respuesta"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notificar cuando termina una respuesta"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifier quand une réponse se termine"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifier quand une réponse se termine"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifica quando una risposta finisce"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifica quando una risposta finisce"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notificar quando uma resposta terminar"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notificar quando uma resposta terminar"
           }
         }
       }
     },
-    "Notify when input is required" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notify when input is required"
+    "Notify when input is required": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notify when input is required"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notificar cuando se requiere entrada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notificar cuando se requiere entrada"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifier quand une entrée est requise"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifier quand une entrée est requise"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifica quando è richiesto input"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifica quando è richiesto input"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notificar quando a entrada é necessária"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notificar quando a entrada é necessária"
           }
         }
       }
     },
-    "now" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "now"
+    "now": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "now"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "ahora"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "ahora"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "maintenant"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "maintenant"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "adesso"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "adesso"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "agora"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "agora"
           }
         }
       }
     },
-    "Off" : {
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Désactivé"
+    "Off": {
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désactivé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disattivato"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disattivato"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desligado"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desligado"
           }
         }
       }
     },
-    "On" : {
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activé"
+    "On": {
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Attivato"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attivato"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ligado"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ligado"
           }
         }
       }
     },
-    "On launch" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "On launch"
+    "On launch": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "On launch"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Al iniciar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Al iniciar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Au lancement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Au lancement"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "All'avvio"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All'avvio"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Na inicialização"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Na inicialização"
           }
         }
       }
     },
-    "Open Project" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvrir le projet"
+    "Open Project": {
+      "extractionState": "stale",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir le projet"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apri progetto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri progetto"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir projeto"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir projeto"
           }
         }
       }
     },
-    "Open project with" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open project with"
+    "Open project with": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open project with"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir proyecto con"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir proyecto con"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvrir le projet avec"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir le projet avec"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apri progetto con"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri progetto con"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir projeto com"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir projeto com"
           }
         }
       }
     },
-    "Open the current project in the preferred workspace tool." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the current project in the preferred workspace tool."
+    "Open the current project in the preferred workspace tool.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open the current project in the preferred workspace tool."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abre el proyecto actual en la herramienta de espacio de trabajo preferida."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre el proyecto actual en la herramienta de espacio de trabajo preferida."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvrez le projet actuel dans l'outil d'espace de travail préféré."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrez le projet actuel dans l'outil d'espace de travail préféré."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apri il progetto corrente nello strumento preferito per lo spazio di lavoro."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri il progetto corrente nello strumento preferito per lo spazio di lavoro."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abra o projeto atual na ferramenta de espaço de trabalho preferida."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abra o projeto atual na ferramenta de espaço de trabalho preferida."
           }
         }
       }
     },
-    "Open Workspace" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Workspace"
+    "Open Workspace": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Workspace"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir espacio de trabajo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir espacio de trabajo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvrir l'espace de travail"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir l'espace de travail"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apri spazio di lavoro"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri spazio di lavoro"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir espaço de trabalho"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir espaço de trabalho"
           }
         }
       }
     },
-    "Output" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Output"
+    "Output": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Output"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salida"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salida"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sortie"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sortie"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Output"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Output"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Saída"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saída"
           }
         }
       }
     },
-    "Per-project activity summary" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Per-project activity summary"
+    "Per-project activity summary": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Per-project activity summary"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resumen de actividad por proyecto"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resumen de actividad por proyecto"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Résumé d'activité par projet"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Résumé d'activité par projet"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Riepilogo attività per progetto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riepilogo attività per progetto"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resumo de atividade por projeto"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resumo de atividade por projeto"
           }
         }
       }
     },
-    "Permission required" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permission required"
+    "Permission required": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permission required"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permiso requerido"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permiso requerido"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autorisation requise"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autorisation requise"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permesso richiesto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permesso richiesto"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permissão necessária"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permissão necessária"
           }
         }
       }
     },
-    "Persist YOLO mode for each thread so permission auto-approval comes back the next time you open that workspace." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Persist YOLO mode for each thread so permission auto-approval comes back the next time you open that workspace."
+    "Persist YOLO mode for each thread so permission auto-approval comes back the next time you open that workspace.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Persist YOLO mode for each thread so permission auto-approval comes back the next time you open that workspace."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Guarda el modo YOLO para cada hilo para que la aprobacion automatica de permisos vuelva la proxima vez que abras ese espacio de trabajo."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guarda el modo YOLO para cada hilo para que la aprobacion automatica de permisos vuelva la proxima vez que abras ese espacio de trabajo."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conservez le mode YOLO par conversation afin que l'approbation automatique des permissions revienne la prochaine fois que vous ouvrirez cet espace de travail."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conservez le mode YOLO par conversation afin que l'approbation automatique des permissions revienne la prochaine fois que vous ouvrirez cet espace de travail."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mantieni la modalità YOLO per ogni conversazione affinché l'approvazione automatica dei permessi torni la prossima volta che apri quello spazio di lavoro."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantieni la modalità YOLO per ogni conversazione affinché l'approvazione automatica dei permessi torni la prossima volta che apri quello spazio di lavoro."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Persista o modo YOLO para cada conversa para que a aprovação automática de permissões retorne na próxima vez que você abrir esse espaço de trabalho."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Persista o modo YOLO para cada conversa para que a aprovação automática de permissões retorne na próxima vez que você abrir esse espaço de trabalho."
           }
         }
       }
     },
-    "Pick a presentation mode, then tune the light and dark palettes independently." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pick a presentation mode, then tune the light and dark palettes independently."
+    "Pick a presentation mode, then tune the light and dark palettes independently.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pick a presentation mode, then tune the light and dark palettes independently."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elige un modo de presentacion y luego ajusta de forma independiente las paletas clara y oscura."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige un modo de presentacion y luego ajusta de forma independiente las paletas clara y oscura."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choisissez un mode de présentation, puis ajustez indépendamment les palettes claire et sombre."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisissez un mode de présentation, puis ajustez indépendamment les palettes claire et sombre."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scegli una modalità di presentazione e regola indipendentemente le palette chiara e scura."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scegli una modalità di presentazione e regola indipendentemente le palette chiara e scura."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escolha um modo de apresentação e ajuste as paletas clara e escura independentemente."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escolha um modo de apresentação e ajuste as paletas clara e escura independentemente."
           }
         }
       }
     },
-    "Portuguese" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Portuguese"
+    "Portuguese": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Portuguese"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Portugues"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Portugues"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Portugais"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Portugais"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Portoghese"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Portoghese"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Português"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Português"
           }
         }
       }
     },
-    "Power & notifications" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Power & notifications"
+    "Power & notifications": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Power & notifications"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Energia y notificaciones"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Energia y notificaciones"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alimentation et notifications"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alimentation et notifications"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Energia e notifiche"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Energia e notifiche"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Energia e notificações"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Energia e notificações"
           }
         }
       }
     },
-    "Prefer arrow-to-hand pointer transitions over the default app cursor." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prefer arrow-to-hand pointer transitions over the default app cursor."
+    "Prefer arrow-to-hand pointer transitions over the default app cursor.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prefer arrow-to-hand pointer transitions over the default app cursor."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prefiere transiciones del puntero de flecha a mano en lugar del cursor predeterminado de la app."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prefiere transiciones del puntero de flecha a mano en lugar del cursor predeterminado de la app."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Préférez les transitions curseur flèche-vers-main plutôt que le curseur par défaut de l'application."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Préférez les transitions curseur flèche-vers-main plutôt que le curseur par défaut de l'application."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preferisci le transizioni da freccia a mano rispetto al cursore predefinito dell'app."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preferisci le transizioni da freccia a mano rispetto al cursore predefinito dell'app."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prefira transições de cursor de seta para mão em vez do cursor padrão do app."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prefira transições de cursor de seta para mão em vez do cursor padrão do app."
           }
         }
       }
     },
-    "Preparing" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparing"
+    "Preparing": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparing"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparando"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparando"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Préparation"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Préparation"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparazione"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparazione"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparando"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparando"
           }
         }
       }
     },
-    "Preparing the dashboard" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparing the dashboard"
+    "Preparing the dashboard": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparing the dashboard"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparando el panel"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparando el panel"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Préparation du tableau de bord"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Préparation du tableau de bord"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparazione della dashboard"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparazione della dashboard"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparando o painel"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparando o painel"
           }
         }
       }
     },
-    "Preparing update" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparing update"
+    "Preparing update": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparing update"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparando actualización"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparando actualización"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Préparation de la mise à jour"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Préparation de la mise à jour"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparazione aggiornamento"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparazione aggiornamento"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparando atualização"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparando atualização"
           }
         }
       }
     },
-    "Preparing: %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparing: %@"
+    "Preparing: %@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparing: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparando: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparando: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Préparation : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Préparation : %@"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparazione: %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparazione: %@"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparando: %@"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparando: %@"
           }
         }
       }
     },
-    "Prevent Mac sleep while responses are running" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prevent Mac sleep while responses are running"
+    "Prevent Mac sleep while responses are running": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prevent Mac sleep while responses are running"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Evitar que la Mac duerma mientras hay respuestas en curso"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evitar que la Mac duerma mientras hay respuestas en curso"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Empêcher la mise en veille du Mac pendant l'exécution des réponses"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empêcher la mise en veille du Mac pendant l'exécution des réponses"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impedisci la sospensione del Mac mentre le risposte sono in esecuzione"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impedisci la sospensione del Mac mentre le risposte sono in esecuzione"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prevenir suspensão do Mac enquanto as respostas estão em execução"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prevenir suspensão do Mac enquanto as respostas estão em execução"
           }
         }
       }
     },
-    "Primary text tone for readable content across the shell." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Primary text tone for readable content across the shell."
+    "Primary text tone for readable content across the shell.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Primary text tone for readable content across the shell."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tono principal de texto para un contenido legible en toda la interfaz."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tono principal de texto para un contenido legible en toda la interfaz."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ton du texte principal pour un contenu lisible dans tout le shell."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ton du texte principal pour un contenu lisible dans tout le shell."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tono principale del testo per contenuti leggibili nella shell."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tono principale del testo per contenuti leggibili nella shell."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tom de texto primário para conteúdo legível em todo o shell."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tom de texto primário para conteúdo legível em todo o shell."
           }
         }
       }
     },
-    "Primary tint used for controls, highlights, and actions." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Primary tint used for controls, highlights, and actions."
+    "Primary tint used for controls, highlights, and actions.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Primary tint used for controls, highlights, and actions."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tinte principal usado para controles, resaltados y acciones."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tinte principal usado para controles, resaltados y acciones."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Teinte principale utilisée pour les contrôles, les surlignages et les actions."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teinte principale utilisée pour les contrôles, les surlignages et les actions."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tinta principale usata per controlli, evidenziazioni e azioni."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tinta principale usata per controlli, evidenziazioni e azioni."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Matiz primária usada em controles, destaques e ações."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Matiz primária usada em controles, destaques e ações."
           }
         }
       }
     },
-    "Projects" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Projects"
+    "Projects": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Projects"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proyectos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proyectos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Projets"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Projets"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Progetti"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Progetti"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Projetos"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Projetos"
           }
         }
       }
     },
-    "prompt" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "prompt"
+    "prompt": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "prompt"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "prompt"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "prompt"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "invite"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "invite"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "prompt"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "prompt"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "prompt"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "prompt"
           }
         }
       }
     },
-    "Prompt" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prompt"
+    "Prompt": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prompt"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prompt"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prompt"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prompt"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prompt"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prompt"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prompt"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prompt"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prompt"
           }
         }
       }
     },
-    "prompts" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "prompts"
+    "prompts": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "prompts"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "prompts"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "prompts"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "invites"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "invites"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "prompt"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "prompt"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "prompts"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "prompts"
           }
         }
       }
     },
-    "Provider" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Provider"
+    "Provider": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Provider"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proveedor"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proveedor"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fournisseur"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fournisseur"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Provider"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Provider"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Provedor"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Provedor"
           }
         }
       }
     },
-    "Push" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Push"
+    "Push": {
+      "extractionState": "stale",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Push"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Push"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Push"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Push"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Push"
           }
         }
       }
     },
-    "Pushing" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pushing"
+    "Pushing": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pushing"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviando"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviando"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Push en cours"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Push en cours"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Push in corso"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Push in corso"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviando"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviando"
           }
         }
       }
     },
-    "px" : {
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "px"
+    "px": {
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "px"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "px"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "px"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "px"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "px"
           }
         }
       }
     },
-    "Question" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Question"
+    "Question": {
+      "extractionState": "stale",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Question"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Domanda"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domanda"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pergunta"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pergunta"
           }
         }
       }
     },
-    "Questions" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Questions"
+    "Questions": {
+      "extractionState": "stale",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Questions"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Domande"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domande"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Perguntas"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Perguntas"
           }
         }
       }
     },
-    "Queue message" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Queue message"
+    "Queue message": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue message"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Poner en cola el mensaje"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Poner en cola el mensaje"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mettre le message en file d'attente"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Mettre le message en file d'attente"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Metti in coda il messaggio"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metti in coda il messaggio"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enfileirar mensagem"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enfileirar mensagem"
           }
         }
       }
     },
-    "Queued" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Queued"
+    "Queued": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queued"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "En cola"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "En cola"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "En file"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "En file"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "In coda"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "In coda"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Na fila"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Na fila"
           }
         }
       }
     },
-    "+%@ more" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "+%@ more"
+    "+%@ more": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "+%@ more"
           }
         }
       }
     },
-    "%@ attachment" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ attachment"
+    "%@ attachment": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ attachment"
           }
         }
       }
     },
-    "%@ attachments" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ attachments"
+    "%@ attachments": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ attachments"
           }
         }
       }
     },
-    "Queued %@ of %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Queued %@ of %@"
+    "Queued %@ of %@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queued %@ of %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "En cola %@ de %@"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "En cola %@ de %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "En file %@ sur %@"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "En file %@ sur %@"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "In coda %@ di %@"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "In coda %@ di %@"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Na fila %@ de %@"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Na fila %@ de %@"
           }
         }
       }
     },
-    "Queued %lld of %lld" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Queued %1$lld of %2$lld"
+    "Queued %lld of %lld": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queued %1$lld of %2$lld"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "En attente %1$lld sur %2$lld"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En attente %1$lld sur %2$lld"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "In coda %1$lld di %2$lld"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In coda %1$lld di %2$lld"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Na fila %1$lld de %2$lld"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Na fila %1$lld de %2$lld"
           }
         }
       }
     },
-    "Ranked by assistant message count" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ranked by assistant message count"
+    "Ranked by assistant message count": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ranked by assistant message count"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ordenado por cantidad de mensajes del asistente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ordenado por cantidad de mensajes del asistente"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Classés par nombre de messages de l'assistant"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Classés par nombre de messages de l'assistant"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ordinato per numero di messaggi dell'assistente"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ordinato per numero di messaggi dell'assistente"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ordenado pela contagem de mensagens do assistente"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ordenado pela contagem de mensagens do assistente"
           }
         }
       }
     },
-    "Ready" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ready"
+    "Ready": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ready"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lista"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lista"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prête"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prête"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pronto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pronto"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pronta"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pronta"
           }
         }
       }
     },
-    "Ready to install" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ready to install"
+    "Ready to install": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ready to install"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lista para instalar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lista para instalar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prête à installer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prête à installer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pronto per l'installazione"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pronto per l'installazione"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pronta para instalar"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pronta para instalar"
           }
         }
       }
     },
-    "Reasoning" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reasoning"
+    "Reasoning": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reasoning"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Razonamiento"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Razonamiento"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Raisonnement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Raisonnement"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ragionamento"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ragionamento"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Raciocínio"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Raciocínio"
           }
         }
       }
     },
-    "Refresh Threads" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualiser les conversations"
+    "Refresh Threads": {
+      "extractionState": "stale",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualiser les conversations"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiorna conversazioni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiorna conversazioni"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atualizar conversas"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizar conversas"
           }
         }
       }
     },
-    "Remember YOLO mode per thread" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remember YOLO mode per thread"
+    "Remember YOLO mode per thread": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remember YOLO mode per thread"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recordar el modo YOLO por hilo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recordar el modo YOLO por hilo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mémoriser le mode YOLO par conversation"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mémoriser le mode YOLO par conversation"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ricorda la modalità YOLO per ogni conversazione"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ricorda la modalità YOLO per ogni conversazione"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lembrar modo YOLO por conversa"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lembrar modo YOLO por conversa"
           }
         }
       }
     },
-    "Remove" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Supprimer"
+    "Remove": {
+      "extractionState": "stale",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rimuovi"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rimuovi"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remover"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover"
           }
         }
       }
     },
-    "Remove attachment" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Supprimer la pièce jointe"
+    "Remove attachment": {
+      "extractionState": "stale",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer la pièce jointe"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rimuovi allegato"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rimuovi allegato"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remover anexo"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover anexo"
           }
         }
       }
     },
-    "Remove from favorites" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Remove from favorites"
+    "Remove from favorites": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from favorites"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Quitar de favoritos"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Quitar de favoritos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Retirer des favoris"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retirer des favoris"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Rimuovi dai preferiti"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rimuovi dai preferiti"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Remover dos favoritos"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remover dos favoritos"
           }
         }
       }
     },
-    "Rename" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rename"
+    "Rename": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renombrar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renombrar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renommer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renommer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rinomina"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rinomina"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renomear"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renomear"
           }
         }
       }
     },
-    "Rename Thread" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renommer la conversation"
+    "Rename Thread": {
+      "extractionState": "stale",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renommer la conversation"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rinomina conversazione"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rinomina conversazione"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renomear conversa"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renomear conversa"
           }
         }
       }
     },
-    "Restore drafts when reopening threads" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restore drafts when reopening threads"
+    "Restore drafts when reopening threads": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore drafts when reopening threads"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restaurar borradores al reabrir hilos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaurar borradores al reabrir hilos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restaurer les brouillons lors de la réouverture des conversations"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaurer les brouillons lors de la réouverture des conversations"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ripristina bozze quando riapri le conversazioni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ripristina bozze quando riapri le conversazioni"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restaurar rascunhos ao reabrir conversas"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaurar rascunhos ao reabrir conversas"
           }
         }
       }
     },
-    "retrying" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "retrying"
+    "retrying": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "retrying"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "reintentando"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "reintentando"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "réessai"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "réessai"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "riprovando"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "riprovando"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "tentando novamente"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "tentando novamente"
           }
         }
       }
     },
-    "Return" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Return"
+    "Return": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Return"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retorno"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retorno"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retour"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retour"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invio"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invio"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter"
           }
         }
       }
     },
-    "Reveal in Finder" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher dans le Finder"
+    "Reveal in Finder": {
+      "extractionState": "stale",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher dans le Finder"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostra nel Finder"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra nel Finder"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar no Finder"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar no Finder"
           }
         }
       }
     },
-    "Revert" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Revenir"
+    "Revert": {
+      "extractionState": "stale",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revenir"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annulla"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annulla"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reverter"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reverter"
           }
         }
       }
     },
-    "Revert to this message" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Revert to this message"
+    "Revert to this message": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Revert to this message"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Revertir a este mensaje"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Revertir a este mensaje"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Revenir à ce message"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Revenir à ce message"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Torna a questo messaggio"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Torna a questo messaggio"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reverter para esta mensagem"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reverter para esta mensagem"
           }
         }
       }
     },
-    "Revert to this point" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Revert to this point"
+    "Revert to this point": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revert to this point"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Revertir hasta este punto"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revertir hasta este punto"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Revenir à ce point"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revenir à ce point"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Torna a questo punto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Torna a questo punto"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reverter até este ponto"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reverter até este ponto"
           }
         }
       }
     },
-    "Reverting..." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restauration en cours..."
+    "Reverting...": {
+      "extractionState": "stale",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restauration en cours..."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annullamento..."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annullamento..."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Revertendo..."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revertendo..."
           }
         }
       }
     },
-    "Review answers" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Review answers"
+    "Review answers": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review answers"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Revisar respuestas"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revisar respuestas"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Revoir les réponses"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revoir les réponses"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rivedi risposte"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rivedi risposte"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Revisar respostas"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revisar respostas"
           }
         }
       }
     },
-    "running" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "running"
+    "running": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "running"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "en ejecución"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "en ejecución"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "en cours d'exécution"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "en cours d'exécution"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "in esecuzione"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "in esecuzione"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "em execução"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "em execução"
           }
         }
       }
     },
-    "Save" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save"
+    "Save": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Guardar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enregistrer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salva"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salva"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salvar"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salvar"
           }
         }
       }
     },
-    "Search agents" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search agents"
+    "Search agents": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search agents"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar agentes"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar agentes"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rechercher des agents"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher des agents"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cerca agenti"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerca agenti"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pesquisar agentes"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pesquisar agentes"
           }
         }
       }
     },
-    "Search apps" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search apps"
+    "Search apps": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search apps"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar apps"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar apps"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rechercher des applications"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher des applications"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cerca app"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerca app"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pesquisar aplicativos"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pesquisar aplicativos"
           }
         }
       }
     },
-    "Search branches" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search branches"
+    "Search branches": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search branches"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar ramas"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar ramas"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rechercher des branches"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher des branches"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cerca branch"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerca branch"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pesquisar ramos"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pesquisar ramos"
           }
         }
       }
     },
-    "Search code fonts" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search code fonts"
+    "Search code fonts": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search code fonts"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar fuentes de codigo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar fuentes de codigo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rechercher des polices de code"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher des polices de code"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cerca font per il codice"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerca font per il codice"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pesquisar fontes de código"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pesquisar fontes de código"
           }
         }
       }
     },
-    "Search languages" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search languages"
+    "Search languages": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search languages"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar idiomas"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar idiomas"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rechercher des langues"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher des langues"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cerca lingue"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerca lingue"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pesquisar idiomas"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pesquisar idiomas"
           }
         }
       }
     },
-    "Search models" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search models"
+    "Search models": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search models"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar modelos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar modelos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rechercher des modèles"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher des modèles"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cerca modelli"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerca modelli"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pesquisar modelos"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pesquisar modelos"
           }
         }
       }
     },
-    "Search reasoning" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search reasoning"
+    "Search reasoning": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search reasoning"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar razonamiento"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar razonamiento"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rechercher le raisonnement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher le raisonnement"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cerca ragionamento"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerca ragionamento"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pesquisar raciocínio"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pesquisar raciocínio"
           }
         }
       }
     },
-    "Search UI fonts" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search UI fonts"
+    "Search UI fonts": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search UI fonts"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar fuentes de interfaz"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar fuentes de interfaz"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rechercher des polices d'interface"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher des polices d'interface"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cerca font interfaccia"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerca font interfaccia"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pesquisar fontes de interface"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pesquisar fontes de interface"
           }
         }
       }
     },
-    "Select all that apply" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select all that apply"
+    "Select all that apply": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select all that apply"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selecciona todas las que correspondan"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecciona todas las que correspondan"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélectionnez tout ce qui s'applique"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionnez tout ce qui s'applique"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleziona tutto ciò che si applica"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleziona tutto ciò che si applica"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selecione todos os que se aplicam"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecione todos os que se aplicam"
           }
         }
       }
     },
-    "Select model" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select model"
+    "Select model": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select model"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleccionar modelo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccionar modelo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélectionner un modèle"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionner un modèle"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleziona modello"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleziona modello"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selecionar modelo"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecionar modelo"
           }
         }
       }
     },
-    "Send answer" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send answer"
+    "Send answer": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send answer"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviar respuesta"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviar respuesta"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Envoyer la réponse"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envoyer la réponse"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invia risposta"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invia risposta"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviar resposta"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviar resposta"
           }
         }
       }
     },
-    "Send message (Command-Return)" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Send message (Command-Return)"
+    "Send message (Command-Return)": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Send message (Command-Return)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enviar mensaje (Command-Retorno)"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enviar mensaje (Command-Retorno)"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Envoyer le message (Commande-Retour)"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Envoyer le message (Commande-Retour)"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Invia messaggio (Command-Return)"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Invia messaggio (Command-Return)"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enviar mensagem (Command-Return)"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enviar mensagem (Command-Return)"
           }
         }
       }
     },
-    "Send message (Return)" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Send message (Return)"
+    "Send message (Return)": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Send message (Return)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enviar mensaje (Return)"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enviar mensaje (Return)"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Envoyer le message (Retour)"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Envoyer le message (Retour)"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Invia messaggio (Return)"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Invia messaggio (Return)"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enviar mensagem (Return)"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enviar mensagem (Return)"
           }
         }
       }
     },
-    "Send messages with" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send messages with"
+    "Send messages with": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send messages with"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviar mensajes con"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviar mensajes con"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Envoyer des messages avec"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envoyer des messages avec"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invia messaggi con"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invia messaggi con"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviar mensagens com"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviar mensagens com"
           }
         }
       }
     },
-    "Send once done" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send once done"
+    "Send once done": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send once done"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviar al terminar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviar al terminar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Envoyer une fois terminé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envoyer une fois terminé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invia una volta terminato"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invia una volta terminato"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviar quando pronto"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviar quando pronto"
           }
         }
       }
     },
-    "Session autonomy" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Session autonomy"
+    "Session autonomy": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Session autonomy"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autonomia de la sesion"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autonomia de la sesion"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autonomie de session"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autonomie de session"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autonomia sessione"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autonomia sessione"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autonomia da sessão"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autonomia da sessão"
           }
         }
       }
     },
-    "Session stats" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Session stats"
+    "Session stats": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Session stats"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estadisticas de la sesion"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estadisticas de la sesion"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Statistiques de session"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistiques de session"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Statistiche sessione"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistiche sessione"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estatísticas da sessão"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estatísticas da sessão"
           }
         }
       }
     },
-    "Session Stats" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Session Stats"
+    "Session Stats": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Session Stats"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estadisticas de la sesion"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estadisticas de la sesion"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Statistiques de session"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistiques de session"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Statistiche sessione"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistiche sessione"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estatísticas da sessão"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estatísticas da sessão"
           }
         }
       }
     },
-    "Session stats unavailable" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Session stats unavailable"
+    "Session stats unavailable": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Session stats unavailable"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estadisticas de la sesion no disponibles"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estadisticas de la sesion no disponibles"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Statistiques de session indisponibles"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistiques de session indisponibles"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Statistiche sessione non disponibili"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistiche sessione non disponibili"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estatísticas da sessão indisponíveis"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estatísticas da sessão indisponíveis"
           }
         }
       }
     },
-    "Set Reasoning" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set Reasoning"
+    "Set Reasoning": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set Reasoning"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurar razonamiento"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurar razonamiento"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Définir le raisonnement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Définir le raisonnement"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Imposta ragionamento"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imposta ragionamento"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Definir raciocínio"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Definir raciocínio"
           }
         }
       }
     },
-    "Set the current reasoning level, like low, medium, or high." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set the current reasoning level, like low, medium, or high."
+    "Set the current reasoning level, like low, medium, or high.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set the current reasoning level, like low, medium, or high."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Define el nivel de razonamiento actual, como bajo, medio o alto."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Define el nivel de razonamiento actual, como bajo, medio o alto."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Définissez le niveau de raisonnement actuel, comme faible, moyen ou élevé."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Définissez le niveau de raisonnement actuel, comme faible, moyen ou élevé."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Imposta il livello di ragionamento corrente, ad esempio basso, medio o alto."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imposta il livello di ragionamento corrente, ad esempio basso, medio o alto."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Defina o nível atual de raciocínio, como baixo, médio ou alto."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Defina o nível atual de raciocínio, como baixo, médio ou alto."
           }
         }
       }
     },
-    "Settings" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Settings"
+    "Settings": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajustes"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Paramètres"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paramètres"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impostazioni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impostazioni"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurações"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurações"
           }
         }
       }
     },
-    "Show %@ more" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show %@ more"
+    "Show %@ more": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Show %@ more"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mostrar %@ más"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Mostrar %@ más"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Afficher %@ de plus"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Afficher %@ de plus"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mostra %@ in più"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Mostra %@ in più"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mostrar mais %@"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Mostrar mais %@"
           }
         }
       }
     },
-    "Show a macOS notification after a response completes while the app is unfocused." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show a macOS notification after a response completes while the app is unfocused."
+    "Show a macOS notification after a response completes while the app is unfocused.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show a macOS notification after a response completes while the app is unfocused."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Muestra una notificacion de macOS cuando una respuesta termina mientras la app no esta enfocada."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muestra una notificacion de macOS cuando una respuesta termina mientras la app no esta enfocada."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher une notification macOS après qu'une réponse se termine pendant que l'application est en arrière-plan."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher une notification macOS après qu'une réponse se termine pendant que l'application est en arrière-plan."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostra una notifica macOS quando una risposta termina mentre l'app non è focalizzata."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra una notifica macOS quando una risposta termina mentre l'app non è focalizzata."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exiba uma notificação do macOS após uma resposta terminar enquanto o app estiver sem foco."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exiba uma notificação do macOS após uma resposta terminar enquanto o app estiver sem foco."
           }
         }
       }
     },
-    "Show a macOS notification when a permission request or question is waiting for you while NeoCode is unfocused." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show a macOS notification when a permission request or question is waiting for you while NeoCode is unfocused."
+    "Show a macOS notification when a permission request or question is waiting for you while NeoCode is unfocused.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show a macOS notification when a permission request or question is waiting for you while NeoCode is unfocused."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Muestra una notificacion de macOS cuando una solicitud de permiso o pregunta te esta esperando mientras NeoCode no esta enfocado."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muestra una notificacion de macOS cuando una solicitud de permiso o pregunta te esta esperando mientras NeoCode no esta enfocado."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher une notification macOS lorsqu'une demande d'autorisation ou une question vous attend pendant que NeoCode est en arrière-plan."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher une notification macOS lorsqu'une demande d'autorisation ou une question vous attend pendant que NeoCode est en arrière-plan."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostra una notifica macOS quando una richiesta di permesso o una domanda ti aspetta mentre NeoCode non è focalizzato."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra una notifica macOS quando una richiesta di permesso o una domanda ti aspetta mentre NeoCode non è focalizzato."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostre uma notificação do macOS quando uma solicitação de permissão ou pergunta estiver esperando por você enquanto o NeoCode estiver sem foco."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostre uma notificação do macOS quando uma solicitação de permissão ou pergunta estiver esperando por você enquanto o NeoCode estiver sem foco."
           }
         }
       }
     },
-    "Show less" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show less"
+    "Show less": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Show less"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mostrar menos"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Mostrar menos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Afficher moins"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Afficher moins"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mostra meno"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Mostra meno"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mostrar menos"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Mostrar menos"
           }
         }
       }
     },
-    "Slash Commands" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Slash Commands"
+    "Slash Commands": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Slash Commands"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comandos slash"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comandos slash"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commandes Slash"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commandes Slash"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comandi slash"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comandi slash"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comandos de barra"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comandos de barra"
           }
         }
       }
     },
-    "Spanish" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spanish"
+    "Spanish": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spanish"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Espanol"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Espanol"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Espagnol"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Espagnol"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spagnolo"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spagnolo"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Espanhol"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Espanhol"
           }
         }
       }
     },
-    "Sparkle delivery" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sparkle delivery"
+    "Sparkle delivery": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sparkle delivery"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualizaciones con Sparkle"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizaciones con Sparkle"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Livraison Sparkle"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Livraison Sparkle"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consegna Sparkle"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consegna Sparkle"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entrega Sparkle"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entrega Sparkle"
           }
         }
       }
     },
-    "Sparkle finished downloading version %@ and is unpacking it for installation." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sparkle finished downloading version %@ and is unpacking it for installation."
+    "Sparkle finished downloading version %@ and is unpacking it for installation.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sparkle finished downloading version %@ and is unpacking it for installation."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sparkle terminó de descargar la versión %@ y la está preparando para su instalación."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sparkle terminó de descargar la versión %@ y la está preparando para su instalación."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sparkle a terminé de télécharger la version %@ et la prépare pour l'installation."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sparkle a terminé de télécharger la version %@ et la prépare pour l'installation."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sparkle ha finito di scaricare la versione %@ e la sta preparando per l'installazione."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sparkle ha finito di scaricare la versione %@ e la sta preparando per l'installazione."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O Sparkle terminou de baixar a versão %@ e está preparando-a para instalação."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Sparkle terminou de baixar a versão %@ e está preparando-a para instalação."
           }
         }
       }
     },
-    "Sparkle is installing version %@. NeoCode may relaunch automatically when the process completes." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sparkle is installing version %@. NeoCode may relaunch automatically when the process completes."
+    "Sparkle is installing version %@. NeoCode may relaunch automatically when the process completes.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sparkle is installing version %@. NeoCode may relaunch automatically when the process completes."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sparkle está instalando la versión %@. NeoCode puede reiniciarse automáticamente cuando termine el proceso."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sparkle está instalando la versión %@. NeoCode puede reiniciarse automáticamente cuando termine el proceso."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sparkle installe la version %@. NeoCode peut redémarrer automatiquement à la fin du processus."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sparkle installe la version %@. NeoCode peut redémarrer automatiquement à la fin du processus."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sparkle sta installando la versione %@. NeoCode potrebbe riavviarsi automaticamente al termine del processo."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sparkle sta installando la versione %@. NeoCode potrebbe riavviarsi automaticamente al termine del processo."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O Sparkle está instalando a versão %@. O NeoCode pode reiniciar automaticamente quando o processo terminar."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Sparkle está instalando a versão %@. O NeoCode pode reiniciar automaticamente quando o processo terminar."
           }
         }
       }
     },
-    "Start a thread" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Démarrer une conversation"
+    "Start a thread": {
+      "extractionState": "stale",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Démarrer une conversation"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avvia una conversazione"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avvia una conversazione"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Começar uma conversa"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Começar uma conversa"
           }
         }
       }
     },
-    "Start by describing a task, asking a question, or pasting in code. Your first message will kick off the session." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start by describing a task, asking a question, or pasting in code. Your first message will kick off the session."
+    "Start by describing a task, asking a question, or pasting in code. Your first message will kick off the session.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start by describing a task, asking a question, or pasting in code. Your first message will kick off the session."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Empieza describiendo una tarea, haciendo una pregunta o pegando codigo. Tu primer mensaje iniciara la sesion."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empieza describiendo una tarea, haciendo una pregunta o pegando codigo. Tu primer mensaje iniciara la sesion."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commencez par décrire une tâche, poser une question ou coller du code. Votre premier message lancera la session."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commencez par décrire une tâche, poser une question ou coller du code. Votre premier message lancera la session."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inizia descrivendo un'attività, ponendo una domanda o incollando del codice. Il tuo primo messaggio avvierà la sessione."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inizia descrivendo un'attività, ponendo una domanda o incollando del codice. Il tuo primo messaggio avvierà la sessione."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comece descrevendo uma tarefa, fazendo uma pergunta ou colando código. Sua primeira mensagem iniciará a sessão."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comece descrevendo uma tarefa, fazendo uma pergunta ou colando código. Sua primeira mensagem iniciará a sessão."
           }
         }
       }
     },
-    "Start on the dashboard or restore the last workspace you were actively using." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start on the dashboard or restore the last workspace you were actively using."
+    "Start on the dashboard or restore the last workspace you were actively using.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start on the dashboard or restore the last workspace you were actively using."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inicia en el panel o restaura el ultimo espacio de trabajo que estabas usando activamente."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicia en el panel o restaura el ultimo espacio de trabajo que estabas usando activamente."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commencez sur le tableau de bord ou restaurez le dernier espace de travail que vous utilisiez activement."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commencez sur le tableau de bord ou restaurez le dernier espace de travail que vous utilisiez activement."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inizia dalla dashboard o ripristina l'ultimo spazio di lavoro che stavi usando attivamente."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inizia dalla dashboard o ripristina l'ultimo spazio di lavoro che stavi usando attivamente."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comece pelo painel ou restaure o último espaço de trabalho que você estava usando ativamente."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comece pelo painel ou restaure o último espaço de trabalho que você estava usando ativamente."
           }
         }
       }
     },
-    "Startup & workspace" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Startup & workspace"
+    "Startup & workspace": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Startup & workspace"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inicio y espacio de trabajo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicio y espacio de trabajo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Démarrage et espace de travail"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Démarrage et espace de travail"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avvio e spazio di lavoro"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avvio e spazio di lavoro"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inicialização e espaço de trabalho"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicialização e espaço de trabalho"
           }
         }
       }
     },
-    "Startup, composer, autonomy, and notifications." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Startup, composer, autonomy, and notifications."
+    "Startup, composer, autonomy, and notifications.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Startup, composer, autonomy, and notifications."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inicio, compositor, autonomia y notificaciones."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicio, compositor, autonomia y notificaciones."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Démarrage, compositeur, autonomie et notifications."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Démarrage, compositeur, autonomie et notifications."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avvio, compositore, autonomia e notifiche."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avvio, compositore, autonomia e notifiche."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inicialização, compositor, autonomia e notificações."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicialização, compositor, autonomia e notificações."
           }
         }
       }
     },
-    "Stats will appear after the session records assistant usage." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stats will appear after the session records assistant usage."
+    "Stats will appear after the session records assistant usage.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stats will appear after the session records assistant usage."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Las estadisticas apareceran despues de que la sesion registre uso del asistente."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las estadisticas apareceran despues de que la sesion registre uso del asistente."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les statistiques apparaîtront après que la session ait enregistré l'utilisation de l'assistant."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les statistiques apparaîtront après que la session ait enregistré l'utilisation de l'assistant."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le statistiche appariranno dopo che la sessione avrà registrato l'utilizzo dell'assistente."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le statistiche appariranno dopo che la sessione avrà registrato l'utilizzo dell'assistente."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "As estatísticas aparecerão depois que a sessão registrar o uso do assistente."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As estatísticas aparecerão depois que a sessão registrar o uso do assistente."
           }
         }
       }
     },
-    "Status" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Status"
+    "Status": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estado"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Statut"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statut"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stato"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stato"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Status"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status"
           }
         }
       }
     },
-    "Status: %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Status: %@"
+    "Status: %@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Status: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Estado: %@"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Estado: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Statut : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Statut : %@"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Stato: %@"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Stato: %@"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Status: %@"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Status: %@"
           }
         }
       }
     },
-    "Steer" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Steer"
+    "Steer": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Steer"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Guiar"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Guiar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Piloter"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Piloter"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Guidare"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Guidare"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dirigir"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Dirigir"
           }
         }
       }
     },
-    "Steer on" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Steer on"
+    "Steer on": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Steer on"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Guiado activado"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Guiado activado"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pilotage activé"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pilotage activé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Guida attiva"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Guida attiva"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Direção ativada"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Direção ativada"
           }
         }
       }
     },
-    "Stop current response" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Stop current response"
+    "Stop current response": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Stop current response"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Detener respuesta actual"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Detener respuesta actual"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Arrêter la réponse en cours"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Arrêter la réponse en cours"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Interrompi la risposta corrente"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Interrompi la risposta corrente"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Parar resposta atual"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Parar resposta atual"
           }
         }
       }
     },
-    "Submit answers" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submit answers"
+    "Submit answers": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submit answers"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviar respuestas"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviar respuestas"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Envoyer les réponses"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envoyer les réponses"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invia risposte"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invia risposte"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviar respostas"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviar respostas"
           }
         }
       }
     },
-    "Summarize the current session to reduce context size." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Summarize the current session to reduce context size."
+    "Summarize the current session to reduce context size.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Summarize the current session to reduce context size."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resume la sesion actual para reducir el tamano del contexto."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resume la sesion actual para reducir el tamano del contexto."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Résumez la session en cours pour réduire la taille du contexte."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Résumez la session en cours pour réduire la taille du contexte."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Riepiloga la sessione corrente per ridurre la dimensione del contesto."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riepiloga la sessione corrente per ridurre la dimensione del contesto."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resuma a sessão atual para reduzir o tamanho do contexto."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resuma a sessão atual para reduzir o tamanho do contexto."
           }
         }
       }
     },
-    "Summarizing the session into a smaller handoff context." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Summarizing the session into a smaller handoff context."
+    "Summarizing the session into a smaller handoff context.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Summarizing the session into a smaller handoff context."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Resumiendo la sesión en un contexto de transferencia más pequeño."
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resumiendo la sesión en un contexto de transferencia más pequeño."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Résumer la session dans un contexte de transition plus compact."
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Résumer la session dans un contexte de transition plus compact."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Sintesi della sessione in un contesto di trasferimento più contenuto."
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sintesi della sessione in un contesto di trasferimento più contenuto."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Resumindo a sessão em um contexto de transição menor."
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resumindo a sessão em um contexto de transição menor."
           }
         }
       }
     },
-    "Switching" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Switching"
+    "Switching": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switching"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambiando"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiando"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Changement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changement"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambio"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambio"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alternando"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alternando"
           }
         }
       }
     },
-    "Syncing threads" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Syncing threads"
+    "Syncing threads": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Syncing threads"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sincronizando hilos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizando hilos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Synchronisation des conversations"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Synchronisation des conversations"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sincronizzazione conversazioni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizzazione conversazioni"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sincronizando conversas"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizando conversas"
           }
         }
       }
     },
-    "Syncing threads..." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Syncing threads..."
+    "Syncing threads...": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Syncing threads..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sincronizando hilos..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizando hilos..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Synchronisation des conversations..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Synchronisation des conversations..."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sincronizzazione conversazioni..."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizzazione conversazioni..."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sincronizando conversas..."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizando conversas..."
           }
         }
       }
     },
-    "System" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "System"
+    "System": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sistema"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sistema"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Système"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Système"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sistema"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sistema"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sistema"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sistema"
           }
         }
       }
     },
-    "Tap to collapse the compacted handoff." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Tap to collapse the compacted handoff."
+    "Tap to collapse the compacted handoff.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tap to collapse the compacted handoff."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Toca para contraer el resumen compacto."
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Toca para contraer el resumen compacto."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Touchez pour réduire le transfert compacté."
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Touchez pour réduire le transfert compacté."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Tocca per comprimere il passaggio compattato."
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tocca per comprimere il passaggio compattato."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Toque para recolher a transferência compactada."
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Toque para recolher a transferência compactada."
           }
         }
       }
     },
-    "Tap to inspect the compacted handoff that future turns build on." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Tap to inspect the compacted handoff that future turns build on."
+    "Tap to inspect the compacted handoff that future turns build on.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tap to inspect the compacted handoff that future turns build on."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Toca para inspeccionar el resumen compacto sobre el que descansan las siguientes interacciones."
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Toca para inspeccionar el resumen compacto sobre el que descansan las siguientes interacciones."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Touchez pour examiner le transfert compacté sur lequel les prochains tours s'appuient."
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Touchez pour examiner le transfert compacté sur lequel les prochains tours s'appuient."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Tocca per ispezionare il passaggio compattato su cui si basano i turni successivi."
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tocca per ispezionare il passaggio compattato su cui si basano i turni successivi."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Toque para inspecionar a transferência compactada que baseia as próximas interações."
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Toque para inspecionar a transferência compactada que baseia as próximas interações."
           }
         }
       }
     },
-    "The agent is retrying after a temporary interruption." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "The agent is retrying after a temporary interruption."
+    "The agent is retrying after a temporary interruption.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The agent is retrying after a temporary interruption."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "El agente está reintentando tras una interrupción temporal."
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "El agente está reintentando tras una interrupción temporal."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "L'agent réessaie après une interruption temporaire."
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "L'agent réessaie après une interruption temporaire."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "L'agente sta ritentando dopo un'interruzione temporanea."
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "L'agente sta ritentando dopo un'interruzione temporanea."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "O agente está tentando novamente após uma interrupção temporária."
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "O agente está tentando novamente após uma interrupção temporária."
           }
         }
       }
     },
-    "The agent is still working." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "The agent is still working."
+    "The agent is still working.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The agent is still working."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "El agente todavía está trabajando."
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "El agente todavía está trabajando."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "L'agent travaille toujours."
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "L'agent travaille toujours."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "L'agente sta ancora lavorando."
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "L'agente sta ancora lavorando."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "O agente ainda está trabalhando."
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "O agente ainda está trabalhando."
           }
         }
       }
     },
-    "The agent wants to continue after repeated failed attempts." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The agent wants to continue after repeated failed attempts."
+    "The agent wants to continue after repeated failed attempts.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The agent wants to continue after repeated failed attempts."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El agente quiere continuar tras varios intentos fallidos."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El agente quiere continuar tras varios intentos fallidos."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'agent souhaite continuer après plusieurs tentatives infructueuses."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'agent souhaite continuer après plusieurs tentatives infructueuses."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'agente vuole continuare dopo ripetuti tentativi falliti."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'agente vuole continuare dopo ripetuti tentativi falliti."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O agente quer continuar após repetidas tentativas falhas."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O agente quer continuar após repetidas tentativas falhas."
           }
         }
       }
     },
-    "The build currently running on this Mac." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The build currently running on this Mac."
+    "The build currently running on this Mac.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The build currently running on this Mac."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La compilacion que se esta ejecutando actualmente en esta Mac."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La compilacion que se esta ejecutando actualmente en esta Mac."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La build actuellement exécutée sur ce Mac."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La build actuellement exécutée sur ce Mac."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La build attualmente in esecuzione su questo Mac."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La build attualmente in esecuzione su questo Mac."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A compilação atualmente em execução neste Mac."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A compilação atualmente em execução neste Mac."
           }
         }
       }
     },
-    "The most recent time this Mac finished talking to the release feed." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The most recent time this Mac finished talking to the release feed."
+    "The most recent time this Mac finished talking to the release feed.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The most recent time this Mac finished talking to the release feed."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La ultima vez que esta Mac termino de consultar el feed de versiones."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La ultima vez que esta Mac termino de consultar el feed de versiones."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La dernière fois que ce Mac a communiqué avec le flux de releases."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La dernière fois que ce Mac a communiqué avec le flux de releases."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'ultima volta che questo Mac ha terminato la comunicazione con il feed delle release."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'ultima volta che questo Mac ha terminato la comunicazione con il feed delle release."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A última vez que este Mac terminou de conversar com o feed de lançamentos."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A última vez que este Mac terminou de conversar com o feed de lançamentos."
           }
         }
       }
     },
-    "The newest signed release Sparkle has found for this channel." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The newest signed release Sparkle has found for this channel."
+    "The newest signed release Sparkle has found for this channel.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The newest signed release Sparkle has found for this channel."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La version firmada mas reciente que Sparkle encontro para este canal."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La version firmada mas reciente que Sparkle encontro para este canal."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La dernière release signée trouvée par Sparkle pour ce canal."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La dernière release signée trouvée par Sparkle pour ce canal."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'ultima release firmata che Sparkle ha trovato per questo canale."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'ultima release firmata che Sparkle ha trovato per questo canale."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A versão assinada mais recente que o Sparkle encontrou para este canal."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A versão assinada mais recente que o Sparkle encontrou para este canal."
           }
         }
       }
     },
-    "Theme" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Theme"
+    "Theme": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Theme"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tema"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tema"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thème"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thème"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tema"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tema"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tema"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tema"
           }
         }
       }
     },
-    "Theme, fonts, and interface styling." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Theme, fonts, and interface styling."
+    "Theme, fonts, and interface styling.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Theme, fonts, and interface styling."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tema, fuentes y estilo de la interfaz."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tema, fuentes y estilo de la interfaz."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thème, polices et style d'interface."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thème, polices et style d'interface."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tema, font e stile dell'interfaccia."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tema, font e stile dell'interfaccia."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tema, fontes e estilo da interface."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tema, fontes e estilo da interface."
           }
         }
       }
     },
-    "This matches the TUI behavior: the transcript rewinds, the prompt comes back into the composer, and file edits after that point are rolled back." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This matches the TUI behavior: the transcript rewinds, the prompt comes back into the composer, and file edits after that point are rolled back."
+    "This matches the TUI behavior: the transcript rewinds, the prompt comes back into the composer, and file edits after that point are rolled back.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This matches the TUI behavior: the transcript rewinds, the prompt comes back into the composer, and file edits after that point are rolled back."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esto coincide con el comportamiento del TUI: la transcripcion retrocede, el prompt vuelve al compositor y los cambios de archivos posteriores a ese punto se revierten."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto coincide con el comportamiento del TUI: la transcripcion retrocede, el prompt vuelve al compositor y los cambios de archivos posteriores a ese punto se revierten."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cela reflète le comportement du TUI : la transcription revient en arrière, le prompt revient dans le compositeur et les modifications de fichiers après ce point sont annulées."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cela reflète le comportement du TUI : la transcription revient en arrière, le prompt revient dans le compositeur et les modifications de fichiers après ce point sont annulées."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Questo corrisponde al comportamento dell'interfaccia testuale: la trascrizione si riavvolge, il prompt torna nel compositore e le modifiche ai file dopo quel punto vengono annullate."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Questo corrisponde al comportamento dell'interfaccia testuale: la trascrizione si riavvolge, il prompt torna nel compositore e le modifiche ai file dopo quel punto vengono annullate."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Isso corresponde ao comportamento TUI: a transcrição retrocede, o prompt volta ao compositor e as edições de arquivos após esse ponto são revertidas."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Isso corresponde ao comportamento TUI: a transcrição retrocede, o prompt volta ao compositor e as edições de arquivos após esse ponto são revertidas."
           }
         }
       }
     },
-    "This removes this prompt and %@ later %@ from the transcript and restores it to the composer." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This removes this prompt and %@ later %@ from the transcript and restores it to the composer."
+    "This removes this prompt and %@ later %@ from the transcript and restores it to the composer.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This removes this prompt and %@ later %@ from the transcript and restores it to the composer."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esto elimina este prompt y %@ %@ posteriores de la transcripción y lo devuelve al compositor."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto elimina este prompt y %@ %@ posteriores de la transcripción y lo devuelve al compositor."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cela supprime cette invite ainsi que %@ %@ supplémentaires de la transcription et la replace dans le compositeur."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cela supprime cette invite ainsi que %@ %@ supplémentaires de la transcription et la replace dans le compositeur."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Questo rimuove questo prompt e %@ %@ successivi dalla trascrizione e lo ripristina nel compositore."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Questo rimuove questo prompt e %@ %@ successivi dalla trascrizione e lo ripristina nel compositore."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Isso remove este prompt e %@ %@ posteriores da transcrição e o restaura no compositor."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Isso remove este prompt e %@ %@ posteriores da transcrição e o restaura no compositor."
           }
         }
       }
     },
-    "This removes this prompt from the transcript and restores it to the composer." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This removes this prompt from the transcript and restores it to the composer."
+    "This removes this prompt from the transcript and restores it to the composer.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This removes this prompt from the transcript and restores it to the composer."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esto elimina este prompt de la transcripción y lo devuelve al compositor."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto elimina este prompt de la transcripción y lo devuelve al compositor."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cela supprime cette invite de la transcription et la replace dans le compositeur."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cela supprime cette invite de la transcription et la replace dans le compositeur."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Questo rimuove questo prompt dalla trascrizione e lo ripristina nel compositore."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Questo rimuove questo prompt dalla trascrizione e lo ripristina nel compositore."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Isso remove este prompt da transcrição e o restaura no compositor."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Isso remove este prompt da transcrição e o restaura no compositor."
           }
         }
       }
     },
-    "Thread name" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nom de la conversation"
+    "Thread name": {
+      "extractionState": "stale",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nom de la conversation"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nome conversazione"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome conversazione"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nome da conversa"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome da conversa"
           }
         }
       }
     },
-    "Threads" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Threads"
+    "Threads": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Threads"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hilos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hilos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conversations"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conversations"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conversazioni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conversazioni"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conversas"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conversas"
           }
         }
       }
     },
-    "Toggle YOLO" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toggle YOLO"
+    "Toggle YOLO": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toggle YOLO"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alternar YOLO"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alternar YOLO"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Basculer YOLO"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Basculer YOLO"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Attiva/disattiva YOLO"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attiva/disattiva YOLO"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alternar YOLO"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alternar YOLO"
           }
         }
       }
     },
-    "Token Breakdown" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Token Breakdown"
+    "Token Breakdown": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Token Breakdown"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desglose de tokens"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desglose de tokens"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Répartition des jetons"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Répartition des jetons"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dettaglio token"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dettaglio token"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detalhamento de tokens"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detalhamento de tokens"
           }
         }
       }
     },
-    "Tokens" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tokens"
+    "Tokens": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tokens"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tokens"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tokens"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jetons"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jetons"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Token"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Token"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tokens"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tokens"
           }
         }
       }
     },
-    "Tool Activity" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tool Activity"
+    "Tool Activity": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tool Activity"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actividad de herramientas"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actividad de herramientas"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activité des outils"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activité des outils"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Attività strumento"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attività strumento"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atividade de ferramenta"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atividade de ferramenta"
           }
         }
       }
     },
-    "Total tokens" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Total tokens"
+    "Total tokens": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Total tokens"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tokens totales"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tokens totales"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Total des jetons"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Total des jetons"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Token totali"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Token totali"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Total de tokens"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Total de tokens"
           }
         }
       }
     },
-    "Tune how prompts send and whether NeoCode should keep per-thread drafts waiting for you when you come back." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tune how prompts send and whether NeoCode should keep per-thread drafts waiting for you when you come back."
+    "Tune how prompts send and whether NeoCode should keep per-thread drafts waiting for you when you come back.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tune how prompts send and whether NeoCode should keep per-thread drafts waiting for you when you come back."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajusta como se envian los mensajes y si NeoCode debe conservar borradores por hilo para cuando vuelvas."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajusta como se envian los mensajes y si NeoCode debe conservar borradores por hilo para cuando vuelvas."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajustez la façon dont les prompts sont envoyés et si NeoCode doit conserver les brouillons par conversation lorsque vous revenez."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustez la façon dont les prompts sont envoyés et si NeoCode doit conserver les brouillons par conversation lorsque vous revenez."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Regola come inviano i prompt e se NeoCode deve mantenere le bozze per thread in attesa quando torni."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Regola come inviano i prompt e se NeoCode deve mantenere le bozze per thread in attesa quando torni."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajuste como os prompts são enviados e se o NeoCode deve manter os rascunhos por conversa aguardando você quando voltar."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajuste como os prompts são enviados e se o NeoCode deve manter os rascunhos por conversa aguardando você quando voltar."
           }
         }
       }
     },
-    "Type your own answer" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tapez votre propre réponse"
+    "Type your own answer": {
+      "extractionState": "stale",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tapez votre propre réponse"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Digita la tua risposta"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Digita la tua risposta"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Digite sua própria resposta"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Digite sua própria resposta"
           }
         }
       }
     },
-    "UI font" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "UI font"
+    "UI font": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "UI font"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fuente de interfaz"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fuente de interfaz"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Police d'interface"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Police d'interface"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Font interfaccia"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Font interfaccia"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fonte da interface"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fonte da interface"
           }
         }
       }
     },
-    "UI font size" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "UI font size"
+    "UI font size": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "UI font size"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tamano de fuente de interfaz"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamano de fuente de interfaz"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Taille de police d'interface"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taille de police d'interface"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dimensione font interfaccia"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dimensione font interfaccia"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tamanho da fonte da interface"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamanho da fonte da interface"
           }
         }
       }
     },
-    "Unavailable" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unavailable"
+    "Unavailable": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unavailable"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No disponible"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No disponible"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Indisponible"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indisponible"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Non disponibile"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non disponibile"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Indisponível"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indisponível"
           }
         }
       }
     },
-    "Up to date" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Up to date"
+    "Up to date": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Up to date"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualizado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizado"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "À jour"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "À jour"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiornato"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiornato"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atualizado"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizado"
           }
         }
       }
     },
-    "Update available" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Update available"
+    "Update available": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update available"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualización disponible"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualización disponible"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mise à jour disponible"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mise à jour disponible"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiornamento disponibile"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiornamento disponibile"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atualização disponível"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualização disponível"
           }
         }
       }
     },
-    "Update available: %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Update available: %@"
+    "Update available: %@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update available: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualización disponible: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualización disponible: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mise à jour disponible : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mise à jour disponible : %@"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiornamento disponibile: %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiornamento disponibile: %@"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atualização disponível: %@"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualização disponível: %@"
           }
         }
       }
     },
-    "Update error" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Update error"
+    "Update error": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update error"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error de actualización"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de actualización"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erreur de mise à jour"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erreur de mise à jour"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Errore di aggiornamento"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Errore di aggiornamento"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erro de atualização"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erro de atualização"
           }
         }
       }
     },
-    "Updated %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Updated %@"
+    "Updated %@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updated %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualizado %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizado %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mis à jour %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mis à jour %@"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiornato %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiornato %@"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atualizado %@"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizado %@"
           }
         }
       }
     },
-    "Updates" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Updates"
+    "Updates": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updates"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualizaciones"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizaciones"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mises à jour"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mises à jour"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiornamenti"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiornamenti"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atualizações"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizações"
           }
         }
       }
     },
-    "Usage" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usage"
+    "Usage": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usage"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uso"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uso"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utilisation"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilisation"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utilizzo"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilizzo"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uso"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uso"
           }
         }
       }
     },
-    "Usage in last %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usage in last %@"
+    "Usage in last %@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usage in last %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uso en los ultimos %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uso en los ultimos %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utilisation au cours des %@ derniers"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilisation au cours des %@ derniers"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utilizzo negli ultimi %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilizzo negli ultimi %@"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uso nos últimos %@"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uso nos últimos %@"
           }
         }
       }
     },
-    "Use custom" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utiliser personnalisé"
+    "Use custom": {
+      "extractionState": "stale",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utiliser personnalisé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usa personalizzato"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usa personalizzato"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usar personalizado"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usar personalizado"
           }
         }
       }
     },
-    "Use pointer cursors" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use pointer cursors"
+    "Use pointer cursors": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use pointer cursors"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usar cursores de puntero"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usar cursores de puntero"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utiliser les curseurs pointeur"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utiliser les curseurs pointeur"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usa cursori puntatore"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usa cursori puntatore"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usar cursores de ponteiro"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usar cursores de ponteiro"
           }
         }
       }
     },
-    "Use the folder button in the Threads sidebar to add a workspace. NeoCode will build your dashboard from the sessions it discovers there." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use the folder button in the Threads sidebar to add a workspace. NeoCode will build your dashboard from the sessions it discovers there."
+    "Use the folder button in the Threads sidebar to add a workspace. NeoCode will build your dashboard from the sessions it discovers there.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use the folder button in the Threads sidebar to add a workspace. NeoCode will build your dashboard from the sessions it discovers there."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usa el boton de carpeta en la barra lateral de Hilos para anadir un espacio de trabajo. NeoCode construira tu panel con las sesiones que encuentre alli."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usa el boton de carpeta en la barra lateral de Hilos para anadir un espacio de trabajo. NeoCode construira tu panel con las sesiones que encuentre alli."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utilisez le bouton dossier dans la barre latérale Conversations pour ajouter un espace de travail. NeoCode construira votre tableau de bord à partir des sessions qu'il y découvre."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilisez le bouton dossier dans la barre latérale Conversations pour ajouter un espace de travail. NeoCode construira votre tableau de bord à partir des sessions qu'il y découvre."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usa il pulsante a forma di cartella nella barra laterale Conversazioni per aggiungere uno spazio di lavoro. NeoCode costruirà la dashboard dalle sessioni che trova lì."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usa il pulsante a forma di cartella nella barra laterale Conversazioni per aggiungere uno spazio di lavoro. NeoCode costruirà la dashboard dalle sessioni che trova lì."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use o botão de pasta na barra lateral de conversas para adicionar um espaço de trabalho. O NeoCode construirá seu painel a partir das sessões que encontrar lá."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use o botão de pasta na barra lateral de conversas para adicionar um espaço de trabalho. O NeoCode construirá seu painel a partir das sessões que encontrar lá."
           }
         }
       }
     },
-    "Use the project button in the Threads sidebar to add a folder. NeoCode will only show threads for projects you explicitly add." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utilisez le bouton projet dans la barre latérale Conversations pour ajouter un dossier. NeoCode n'affichera que les conversations des projets que vous ajoutez explicitement."
+    "Use the project button in the Threads sidebar to add a folder. NeoCode will only show threads for projects you explicitly add.": {
+      "extractionState": "stale",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilisez le bouton projet dans la barre latérale Conversations pour ajouter un dossier. NeoCode n'affichera que les conversations des projets que vous ajoutez explicitement."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usa il pulsante progetto nella barra laterale Conversazioni per aggiungere una cartella. NeoCode mostrerà solo le conversazioni per i progetti che aggiungi esplicitamente."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usa il pulsante progetto nella barra laterale Conversazioni per aggiungere una cartella. NeoCode mostrerà solo le conversazioni per i progetti che aggiungi esplicitamente."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use o botão de projeto na barra lateral de conversas para adicionar uma pasta. O NeoCode mostrará apenas as conversas dos projetos que você adicionar explicitamente."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use o botão de projeto na barra lateral de conversas para adicionar uma pasta. O NeoCode mostrará apenas as conversas dos projetos que você adicionar explicitamente."
           }
         }
       }
     },
-    "Used for labels, navigation, settings, and conversation chrome in this theme." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Used for labels, navigation, settings, and conversation chrome in this theme."
+    "Used for labels, navigation, settings, and conversation chrome in this theme.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Used for labels, navigation, settings, and conversation chrome in this theme."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se usa para etiquetas, navegacion, ajustes y elementos de conversacion en este tema."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se usa para etiquetas, navegacion, ajustes y elementos de conversacion en este tema."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utilisé pour les étiquettes, la navigation, les paramètres et le chrome des conversations dans ce thème."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilisé pour les étiquettes, la navigation, les paramètres et le chrome des conversations dans ce thème."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usato per etichette, navigazione, impostazioni e chrome delle conversazioni in questo tema."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usato per etichette, navigazione, impostazioni e chrome delle conversazioni in questo tema."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usado para rótulos, navegação, configurações e a moldura da conversa neste tema."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usado para rótulos, navegação, configurações e a moldura da conversa neste tema."
           }
         }
       }
     },
-    "Used for transcript code, diffs, file references, and inline code in this theme." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Used for transcript code, diffs, file references, and inline code in this theme."
+    "Used for transcript code, diffs, file references, and inline code in this theme.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Used for transcript code, diffs, file references, and inline code in this theme."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se usa para codigo en transcripciones, diffs, referencias de archivos y codigo en linea en este tema."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se usa para codigo en transcripciones, diffs, referencias de archivos y codigo en linea en este tema."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utilisé pour le code de transcription, les diffs, les références aux fichiers et le code inline dans ce thème."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilisé pour le code de transcription, les diffs, les références aux fichiers et le code inline dans ce thème."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usato per il codice della trascrizione, i diff, i riferimenti ai file e il codice inline in questo tema."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usato per il codice della trascrizione, i diff, i riferimenti ai file e il codice inline in questo tema."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usado para código da transcrição, diffs, referências de arquivo e código inline neste tema."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usado para código da transcrição, diffs, referências de arquivo e código inline neste tema."
           }
         }
       }
     },
-    "Used when a project does not already have its own preferred editor or destination." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Used when a project does not already have its own preferred editor or destination."
+    "Used when a project does not already have its own preferred editor or destination.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Used when a project does not already have its own preferred editor or destination."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se usa cuando un proyecto todavia no tiene su propio editor o destino preferido."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se usa cuando un proyecto todavia no tiene su propio editor o destino preferido."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utilisé lorsqu'un projet n'a pas encore son éditeur ou destination préféré."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilisé lorsqu'un projet n'a pas encore son éditeur ou destination préféré."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usato quando un progetto non ha già un editor o una destinazione preferita."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usato quando un progetto non ha già un editor o una destinazione preferita."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usado quando um projeto ainda não tem seu editor ou destino preferido."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usado quando um projeto ainda não tem seu editor ou destino preferido."
           }
         }
       }
     },
-    "Version %@ is ready to download. Use the blue titlebar control or the action below when you want to start it." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version %@ is ready to download. Use the blue titlebar control or the action below when you want to start it."
+    "Version %@ is ready to download. Use the blue titlebar control or the action below when you want to start it.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %@ is ready to download. Use the blue titlebar control or the action below when you want to start it."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La versión %@ está lista para descargarse. Usa el control azul de la barra de título o la acción inferior cuando quieras empezar."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La versión %@ está lista para descargarse. Usa el control azul de la barra de título o la acción inferior cuando quieras empezar."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La version %@ est prête à être téléchargée. Utilisez le contrôle bleu dans la barre de titre ou l'action ci-dessous lorsque vous voulez démarrer."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La version %@ est prête à être téléchargée. Utilisez le contrôle bleu dans la barre de titre ou l'action ci-dessous lorsque vous voulez démarrer."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La versione %@ è pronta per il download. Usa il controllo blu nella barra del titolo o l'azione qui sotto quando vuoi iniziare."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La versione %@ è pronta per il download. Usa il controllo blu nella barra del titolo o l'azione qui sotto quando vuoi iniziare."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A versão %@ está pronta para download. Use o controle azul na barra de título ou a ação abaixo quando quiser começar."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A versão %@ está pronta para download. Use o controle azul na barra de título ou a ação abaixo quando quiser começar."
           }
         }
       }
     },
-    "Version %@ is staged and ready. Install it when you are ready to relaunch NeoCode." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version %@ is staged and ready. Install it when you are ready to relaunch NeoCode."
+    "Version %@ is staged and ready. Install it when you are ready to relaunch NeoCode.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %@ is staged and ready. Install it when you are ready to relaunch NeoCode."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La versión %@ está preparada y lista. Instálala cuando estés listo para reiniciar NeoCode."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La versión %@ está preparada y lista. Instálala cuando estés listo para reiniciar NeoCode."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La version %@ est prête. Installez-la lorsque vous êtes prêt à relancer NeoCode."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La version %@ est prête. Installez-la lorsque vous êtes prêt à relancer NeoCode."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La versione %@ è pronta. Installala quando sei pronto a riavviare NeoCode."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La versione %@ è pronta. Installala quando sei pronto a riavviare NeoCode."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A versão %@ está pronta. Instale-a quando estiver pronto para reiniciar o NeoCode."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A versão %@ está pronta. Instale-a quando estiver pronto para reiniciar o NeoCode."
           }
         }
       }
     },
-    "Waiting for the current response to finish before sending." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Waiting for the current response to finish before sending."
+    "Waiting for the current response to finish before sending.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Waiting for the current response to finish before sending."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Esperando a que termine la respuesta actual antes de enviar."
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Esperando a que termine la respuesta actual antes de enviar."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "En attente de la fin de la réponse en cours avant l'envoi."
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "En attente de la fin de la réponse en cours avant l'envoi."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "In attesa che la risposta corrente finisca prima di inviare."
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "In attesa che la risposta corrente finisca prima di inviare."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Aguardando a conclusão da resposta atual antes de enviar."
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Aguardando a conclusão da resposta atual antes de enviar."
           }
         }
       }
     },
-    "Warm daylight palette for your brighter workspace." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Warm daylight palette for your brighter workspace."
+    "Warm daylight palette for your brighter workspace.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warm daylight palette for your brighter workspace."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Paleta calida de luz diurna para un espacio de trabajo mas luminoso."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paleta calida de luz diurna para un espacio de trabajo mas luminoso."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Palette de lumière du jour chaude pour votre espace de travail plus lumineux."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Palette de lumière du jour chaude pour votre espace de travail plus lumineux."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Palette diurna calda per il tuo spazio di lavoro più luminoso."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Palette diurna calda per il tuo spazio di lavoro più luminoso."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Paleta quente de luz do dia para seu espaço de trabalho mais claro."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paleta quente de luz do dia para seu espaço de trabalho mais claro."
           }
         }
       }
     },
-    "Watching for releases" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Watching for releases"
+    "Watching for releases": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Watching for releases"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Observando nuevas versiones"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observando nuevas versiones"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Surveillance des versions"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surveillance des versions"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Monitoraggio degli aggiornamenti"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monitoraggio degli aggiornamenti"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Monitorando novas versões"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monitorando novas versões"
           }
         }
       }
     },
-    "Welcome to NeoCode!" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Welcome to NeoCode!"
+    "Welcome to NeoCode!": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Welcome to NeoCode!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bienvenido a NeoCode!"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bienvenido a NeoCode!"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bienvenue sur NeoCode!"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bienvenue sur NeoCode!"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benvenuto in NeoCode!"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benvenuto in NeoCode!"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bem-vindo ao NeoCode!"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bem-vindo ao NeoCode!"
           }
         }
       }
     },
-    "Will steer the agent at the next possible moment." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Will steer the agent at the next possible moment."
+    "Will steer the agent at the next possible moment.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Will steer the agent at the next possible moment."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Guiará al agente en el siguiente momento posible."
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Guiará al agente en el siguiente momento posible."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Le pilote prendra le relais dès que possible."
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Le pilote prendra le relais dès que possible."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Gestirà l'agente al prossimo momento possibile."
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gestirà l'agente al prossimo momento possibile."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Controlará o agente no próximo momento possível."
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Controlará o agente no próximo momento possível."
           }
         }
       }
     },
-    "working" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "working"
+    "working": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "working"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "trabajando"
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "trabajando"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "en cours"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "en cours"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "in corso"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "in corso"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "trabalhando"
+        "pt": {
+          "stringUnit": {
+            "state": "new",
+            "value": "trabalhando"
           }
         }
       }
     },
-    "Write a custom response" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Write a custom response"
+    "Write a custom response": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Write a custom response"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escribir una respuesta personalizada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escribir una respuesta personalizada"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Écrire une réponse personnalisée"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Écrire une réponse personnalisée"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scrivi una risposta personalizzata"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scrivi una risposta personalizzata"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escrever uma resposta personalizada"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escrever uma resposta personalizada"
           }
         }
       }
     },
-    "YOLO" : {
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "YOLO"
+    "YOLO": {
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "YOLO"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "YOLO"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "YOLO"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "YOLO"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "YOLO"
           }
         }
       }
     },
-    "YOLO mode" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "YOLO mode"
+    "YOLO mode": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "YOLO mode"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modo YOLO"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo YOLO"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mode YOLO"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mode YOLO"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modalità YOLO"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modalità YOLO"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modo YOLO"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo YOLO"
           }
         }
       }
     },
-    "You are already running the newest compatible signed release available from the appcast feed." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You are already running the newest compatible signed release available from the appcast feed."
+    "You are already running the newest compatible signed release available from the appcast feed.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You are already running the newest compatible signed release available from the appcast feed."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ya estás usando la versión firmada compatible más reciente disponible en el feed appcast."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous utilisez déjà la version signée compatible la plus récente disponible dans le flux appcast."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ya estás usando la versión firmada compatible más reciente disponible en el feed appcast."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stai già usando la versione firmata compatibile più recente disponibile nel feed appcast."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vous utilisez déjà la version signée compatible la plus récente disponible dans le flux appcast."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Você já está usando a versão assinada compatível mais recente disponível no feed appcast."
+          }
+        }
+      }
+    },
+    "Remove Project": {
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer le projet"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stai già usando la versione firmata compatibile più recente disponibile nel feed appcast."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rimuovi progetto"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Você já está usando a versão assinada compatível mais recente disponível no feed appcast."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover projeto"
           }
         }
       }
     }
   },
-  "version" : "1.0"
+  "version": "1.0"
 }


### PR DESCRIPTION
## Summary

- Adds a **"Remove Project"** menu item to the project ellipsis menu in the sidebar
- Shows a confirmation alert before removing
- On confirm: disconnects live state, stops the runtime, removes the project, selects the next available project, and persists

## Screenshots

The "Remove Project" item appears under **Open Project** / **Reveal in Finder** in the project's `⋯` menu, separated by a divider.

## Status

**WIP / Untested** — Metal toolchain download interrupted CI. Awaiting feedback.